### PR TITLE
[Miracle-7] 회원 목표 및 아이콘을 설정하도록 멤버 도메인 & API 변경

### DIFF
--- a/http/member.http
+++ b/http/member.http
@@ -4,7 +4,12 @@ Content-Type: application/json
 
 {
     "name": "강승호",
-    "email": "will.seungho@gmail.com"
+    "email": "will.seungho@gmail.com",
+    "profileIcon": "RED",
+    "goals": [
+        "READING",
+        "EXERCISE"
+    ]
 }
 > {%
 client.global.set("AUTHORIZATION", response.body["data"])
@@ -21,7 +26,19 @@ Authorization: Bearer {{AUTHORIZATION}}
 Content-Type: application/json
 
 {
-    "name": "호승강"
+    "name": "호승강",
+    "profileIcon": "BLUE"
+}
+
+### 회원의 목표 변경 API
+PUT {{host}}/api/v1/member/goal
+Authorization: Bearer {{AUTHORIZATION}}
+Content-Type: application/json
+
+{
+    "goals": [
+        "MEDITATION"
+    ]
 }
 
 ###

--- a/miracle-api/src/main/java/com/depromeet/controller/member/MemberController.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/member/MemberController.java
@@ -6,6 +6,7 @@ import com.depromeet.config.session.MemberSession;
 import com.depromeet.constants.SessionConstants;
 import com.depromeet.service.member.MemberService;
 import com.depromeet.service.member.dto.request.SignUpMemberRequest;
+import com.depromeet.service.member.dto.request.UpdateMemberGoalsRequest;
 import com.depromeet.service.member.dto.request.UpdateMemberInfoRequest;
 import com.depromeet.service.member.dto.response.MemberInfoResponse;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,14 @@ public class MemberController {
     @PutMapping("/api/v1/member")
     public ApiResponse<MemberInfoResponse> updateMemberInfo(@Valid @RequestBody UpdateMemberInfoRequest request, @LoginMember MemberSession memberSession) {
         return ApiResponse.of(memberService.updateMemberInfo(request, memberSession.getMemberId()));
+    }
+
+    /**
+     * 회원의 목표정보를 변경하는 API
+     */
+    @PutMapping("/api/v1/member/goal")
+    public ApiResponse<MemberInfoResponse> updateMemberGoals(@Valid @RequestBody UpdateMemberGoalsRequest request, @LoginMember MemberSession memberSession) {
+        return ApiResponse.of(memberService.updateMemberGoals(request, memberSession.getMemberId()));
     }
 
     /**

--- a/miracle-api/src/main/java/com/depromeet/service/member/MemberService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/MemberService.java
@@ -3,6 +3,7 @@ package com.depromeet.service.member;
 import com.depromeet.domain.member.Member;
 import com.depromeet.domain.member.MemberRepository;
 import com.depromeet.service.member.dto.request.SignUpMemberRequest;
+import com.depromeet.service.member.dto.request.UpdateMemberGoalsRequest;
 import com.depromeet.service.member.dto.request.UpdateMemberInfoRequest;
 import com.depromeet.service.member.dto.response.MemberInfoResponse;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +27,14 @@ public class MemberService {
     @Transactional
     public MemberInfoResponse updateMemberInfo(UpdateMemberInfoRequest request, Long memberId) {
         Member member = MemberServiceUtils.findMemberById(memberRepository, memberId);
-        member.updateInfo(request.getName());
+        member.updateInfo(request.getName(), request.getProfileIcon());
+        return MemberInfoResponse.of(member);
+    }
+
+    @Transactional
+    public MemberInfoResponse updateMemberGoals(UpdateMemberGoalsRequest request, Long memberId) {
+        Member member = MemberServiceUtils.findMemberById(memberRepository, memberId);
+        member.updateMemberGoals(request.getGoals());
         return MemberInfoResponse.of(member);
     }
 

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/request/SignUpMemberRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/request/SignUpMemberRequest.java
@@ -1,11 +1,15 @@
 package com.depromeet.service.member.dto.request;
 
+import com.depromeet.common.Category;
 import com.depromeet.domain.member.Member;
+import com.depromeet.domain.member.ProfileIcon;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -17,14 +21,22 @@ public class SignUpMemberRequest {
     @NotBlank
     private String name;
 
+    @NotNull
+    private ProfileIcon profileIcon;
+
+    @NotNull
+    private List<Category> goals;
+
     @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
-    public SignUpMemberRequest(String email, String name) {
+    public SignUpMemberRequest(String email, String name, ProfileIcon profileIcon, List<Category> goals) {
         this.email = email;
         this.name = name;
+        this.profileIcon = profileIcon;
+        this.goals = goals;
     }
 
     public Member toEntity() {
-        return Member.newInstance(email, name);
+        return Member.newInstance(email, name, profileIcon, goals);
     }
 
 }

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/request/SignUpMemberRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/request/SignUpMemberRequest.java
@@ -1,6 +1,6 @@
 package com.depromeet.service.member.dto.request;
 
-import com.depromeet.common.Category;
+import com.depromeet.domain.common.Category;
 import com.depromeet.domain.member.Member;
 import com.depromeet.domain.member.ProfileIcon;
 import lombok.Builder;

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberGoalsRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberGoalsRequest.java
@@ -1,0 +1,25 @@
+package com.depromeet.service.member.dto.request;
+
+import com.depromeet.common.Category;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class UpdateMemberGoalsRequest {
+
+    @NotNull
+    private List<Category> goals;
+
+    private UpdateMemberGoalsRequest(List<Category> goals) {
+        this.goals = goals;
+    }
+
+    public static UpdateMemberGoalsRequest testInstance(List<Category> goals) {
+        return new UpdateMemberGoalsRequest(goals);
+    }
+
+}

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberGoalsRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberGoalsRequest.java
@@ -1,6 +1,6 @@
 package com.depromeet.service.member.dto.request;
 
-import com.depromeet.common.Category;
+import com.depromeet.domain.common.Category;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberInfoRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberInfoRequest.java
@@ -1,5 +1,6 @@
 package com.depromeet.service.member.dto.request;
 
+import com.depromeet.domain.member.ProfileIcon;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,9 +11,12 @@ public class UpdateMemberInfoRequest {
 
     private String name;
 
+    private ProfileIcon profileIcon;
+
     @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
-    public UpdateMemberInfoRequest(String name) {
+    public UpdateMemberInfoRequest(String name, ProfileIcon profileIcon) {
         this.name = name;
+        this.profileIcon = profileIcon;
     }
 
 }

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/response/MemberInfoResponse.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/response/MemberInfoResponse.java
@@ -1,6 +1,6 @@
 package com.depromeet.service.member.dto.response;
 
-import com.depromeet.common.Category;
+import com.depromeet.domain.common.Category;
 import com.depromeet.domain.member.Member;
 import com.depromeet.domain.member.MemberGoal;
 import com.depromeet.domain.member.ProfileIcon;

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/response/MemberInfoResponse.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/response/MemberInfoResponse.java
@@ -1,9 +1,15 @@
 package com.depromeet.service.member.dto.response;
 
+import com.depromeet.common.Category;
 import com.depromeet.domain.member.Member;
+import com.depromeet.domain.member.MemberGoal;
+import com.depromeet.domain.member.ProfileIcon;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -15,8 +21,15 @@ public class MemberInfoResponse {
 
     private final String name;
 
+    private final ProfileIcon profileIcon;
+
+    private final List<Category> goals;
+
     public static MemberInfoResponse of(Member member) {
-        return new MemberInfoResponse(member.getId(), member.getEmail(), member.getName());
+        List<Category> memberGoalResponses = member.getMemberGoals().stream()
+            .map(MemberGoal::getCategory)
+            .collect(Collectors.toList());
+        return new MemberInfoResponse(member.getId(), member.getEmail(), member.getName(), member.getProfileIcon(), memberGoalResponses);
     }
 
 }

--- a/miracle-api/src/test/java/com/depromeet/service/member/MemberServiceTest.java
+++ b/miracle-api/src/test/java/com/depromeet/service/member/MemberServiceTest.java
@@ -1,6 +1,6 @@
 package com.depromeet.service.member;
 
-import com.depromeet.common.Category;
+import com.depromeet.domain.common.Category;
 import com.depromeet.domain.member.Member;
 import com.depromeet.domain.member.MemberCreator;
 import com.depromeet.domain.member.MemberGoal;

--- a/miracle-api/src/test/java/com/depromeet/service/member/MemberServiceTest.java
+++ b/miracle-api/src/test/java/com/depromeet/service/member/MemberServiceTest.java
@@ -1,9 +1,14 @@
 package com.depromeet.service.member;
 
+import com.depromeet.common.Category;
 import com.depromeet.domain.member.Member;
 import com.depromeet.domain.member.MemberCreator;
+import com.depromeet.domain.member.MemberGoal;
+import com.depromeet.domain.member.MemberGoalRepository;
 import com.depromeet.domain.member.MemberRepository;
+import com.depromeet.domain.member.ProfileIcon;
 import com.depromeet.service.member.dto.request.SignUpMemberRequest;
+import com.depromeet.service.member.dto.request.UpdateMemberGoalsRequest;
 import com.depromeet.service.member.dto.request.UpdateMemberInfoRequest;
 import com.depromeet.service.member.dto.response.MemberInfoResponse;
 import org.junit.jupiter.api.AfterEach;
@@ -12,6 +17,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,6 +33,9 @@ class MemberServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private MemberGoalRepository memberGoalRepository;
+
     private Member member;
 
     @AfterEach
@@ -35,7 +45,7 @@ class MemberServiceTest {
 
     @BeforeEach
     void setUpMemberSample() {
-        member = MemberCreator.create("will.seungho@gmail.com", "강승호");
+        member = MemberCreator.create("will.seungho@gmail.com", "강승호", ProfileIcon.RED, Collections.singletonList(Category.EXERCISE));
     }
 
     @Test
@@ -43,10 +53,12 @@ class MemberServiceTest {
         // given
         String email = "will.seungho@gmail.com";
         String name = "kangseungho";
+        ProfileIcon profileIcon = ProfileIcon.RED;
 
         SignUpMemberRequest request = SignUpMemberRequest.testBuilder()
             .email(email)
             .name(name)
+            .profileIcon(profileIcon)
             .build();
 
         // when
@@ -55,7 +67,50 @@ class MemberServiceTest {
         // then
         List<Member> members = memberRepository.findAll();
         assertThat(members).hasSize(1);
-        assertMemberInfo(members.get(0), email, name);
+        assertMemberInfo(members.get(0), email, name, profileIcon);
+    }
+
+    @Test
+    void 새로운_멤버가_회원가입시_멤버의_목표정보도_저장된다() {
+        // given
+        String email = "will.seungho@gmail.com";
+        String name = "kangseungho";
+        List<Category> goals = Arrays.asList(Category.EXERCISE, Category.READING);
+
+        SignUpMemberRequest request = SignUpMemberRequest.testBuilder()
+            .email(email)
+            .name(name)
+            .goals(goals)
+            .build();
+
+        // when
+        memberService.signUpMember(request);
+
+        // then
+        List<MemberGoal> memberGoals = memberGoalRepository.findAll();
+        assertThat(memberGoals).hasSize(2);
+        assertThat(memberGoals).extracting("category").containsExactly(Category.EXERCISE, Category.READING);
+    }
+
+    @Test
+    void 새로운_멤버가_회원가입시_멤버의_목표를_선택하지_않을수_있다() {
+        // given
+        String email = "will.seungho@gmail.com";
+        String name = "kangseungho";
+        List<Category> goals = Collections.emptyList();
+
+        SignUpMemberRequest request = SignUpMemberRequest.testBuilder()
+            .email(email)
+            .name(name)
+            .goals(goals)
+            .build();
+
+        // when
+        memberService.signUpMember(request);
+
+        // then
+        List<MemberGoal> memberGoals = memberGoalRepository.findAll();
+        assertThat(memberGoals).isEmpty();
     }
 
     @Test
@@ -77,11 +132,13 @@ class MemberServiceTest {
     void 멤버의_회원정보를_변경한다() {
         // given
         String name = "kangseungho";
+        ProfileIcon profileIcon = ProfileIcon.BLUE;
 
         memberRepository.save(member);
 
         UpdateMemberInfoRequest request = UpdateMemberInfoRequest.testBuilder()
             .name(name)
+            .profileIcon(profileIcon)
             .build();
 
         // when
@@ -90,7 +147,7 @@ class MemberServiceTest {
         // then
         List<Member> members = memberRepository.findAll();
         assertThat(members).hasSize(1);
-        assertMemberInfo(members.get(0), member.getEmail(), name);
+        assertMemberInfo(members.get(0), member.getEmail(), name, profileIcon);
     }
 
     @Test
@@ -107,6 +164,39 @@ class MemberServiceTest {
     }
 
     @Test
+    void 멤버의_목표정보를_변경한다() {
+        // given
+        memberRepository.save(member);
+
+        List<Category> categories = Arrays.asList(Category.MEDITATION, Category.READING);
+
+        UpdateMemberGoalsRequest request = UpdateMemberGoalsRequest.testInstance(categories);
+
+        // when
+        memberService.updateMemberGoals(request, member.getId());
+
+        // then
+        List<MemberGoal> memberGoals = memberGoalRepository.findAll();
+        assertThat(memberGoals).hasSize(2);
+        assertThat(memberGoals).extracting("category").containsExactly(Category.MEDITATION, Category.READING);
+    }
+
+    @Test
+    void 멤버의_목표정보를_변경한다_어떤_목표도_없을_수있다() {
+        // given
+        memberRepository.save(member);
+
+        UpdateMemberGoalsRequest request = UpdateMemberGoalsRequest.testInstance(Collections.emptyList());
+
+        // when
+        memberService.updateMemberGoals(request, member.getId());
+
+        // then
+        List<MemberGoal> memberGoals = memberGoalRepository.findAll();
+        assertThat(memberGoals).isEmpty();
+    }
+
+    @Test
     void 내정보를_불러온다() {
         // given
         memberRepository.save(member);
@@ -115,7 +205,7 @@ class MemberServiceTest {
         MemberInfoResponse response = memberService.getMemberInfo(member.getId());
 
         // then
-        assertMemberInfoResponse(response, member.getEmail(), member.getName());
+        assertMemberInfoResponse(response, member.getEmail(), member.getName(), member.getProfileIcon());
     }
 
     @Test
@@ -126,14 +216,16 @@ class MemberServiceTest {
         }).isInstanceOf(IllegalArgumentException.class);
     }
 
-    private void assertMemberInfoResponse(MemberInfoResponse response, String email, String name) {
+    private void assertMemberInfoResponse(MemberInfoResponse response, String email, String name, ProfileIcon profileIcon) {
         assertThat(response.getEmail()).isEqualTo(email);
         assertThat(response.getName()).isEqualTo(name);
+        assertThat(response.getProfileIcon()).isEqualTo(profileIcon);
     }
 
-    private void assertMemberInfo(Member member, String email, String name) {
+    private void assertMemberInfo(Member member, String email, String name, ProfileIcon profileIcon) {
         assertThat(member.getEmail()).isEqualTo(email);
         assertThat(member.getName()).isEqualTo(name);
+        assertThat(member.getProfileIcon()).isEqualTo(profileIcon);
     }
 
 }

--- a/miracle-domain/src/main/java/com/depromeet/common/Category.java
+++ b/miracle-domain/src/main/java/com/depromeet/common/Category.java
@@ -1,0 +1,12 @@
+package com.depromeet.common;
+
+/**
+ * 스케쥴 및 목표에 사용되는 카테고리
+ */
+public enum Category {
+
+    EXERCISE,
+    MEDITATION,
+    READING
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/common/Category.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/common/Category.java
@@ -1,4 +1,4 @@
-package com.depromeet.common;
+package com.depromeet.domain.common;
 
 /**
  * 스케쥴 및 목표에 사용되는 카테고리

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/Member.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/Member.java
@@ -1,6 +1,6 @@
 package com.depromeet.domain.member;
 
-import com.depromeet.common.Category;
+import com.depromeet.domain.common.Category;
 import com.depromeet.domain.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/MemberCreator.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/MemberCreator.java
@@ -1,6 +1,6 @@
 package com.depromeet.domain.member;
 
-import com.depromeet.common.Category;
+import com.depromeet.domain.common.Category;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/MemberCreator.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/MemberCreator.java
@@ -1,7 +1,10 @@
 package com.depromeet.domain.member;
 
+import com.depromeet.common.Category;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberCreator {
@@ -9,6 +12,7 @@ public class MemberCreator {
     public static Member create(String email) {
         return Member.builder()
             .email(email)
+            .name("이름")
             .build();
     }
 
@@ -16,6 +20,15 @@ public class MemberCreator {
         return Member.builder()
             .email(email)
             .name(name)
+            .build();
+    }
+
+    public static Member create(String email, String name, ProfileIcon profileIcon, List<Category> goals) {
+        return Member.builder()
+            .email(email)
+            .name(name)
+            .profileIcon(profileIcon)
+            .goals(goals)
             .build();
     }
 

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/MemberGoal.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/MemberGoal.java
@@ -1,5 +1,6 @@
 package com.depromeet.domain.member;
 
+import com.depromeet.domain.BaseTimeEntity;
 import com.depromeet.domain.common.Category;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -21,7 +22,7 @@ import javax.persistence.ManyToOne;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class MemberGoal {
+public class MemberGoal extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/MemberGoal.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/MemberGoal.java
@@ -1,0 +1,46 @@
+package com.depromeet.domain.member;
+
+import com.depromeet.common.Category;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+/**
+ * 멤버가 선택한 n개의 목표를 관리하는 도메인
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class MemberGoal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    private MemberGoal(Member member, Category category) {
+        this.member = member;
+        this.category = category;
+    }
+
+    public static MemberGoal of(Member member, Category category) {
+        return new MemberGoal(member, category);
+    }
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/MemberGoal.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/MemberGoal.java
@@ -1,6 +1,6 @@
 package com.depromeet.domain.member;
 
-import com.depromeet.common.Category;
+import com.depromeet.domain.common.Category;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/MemberGoalRepository.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/MemberGoalRepository.java
@@ -1,0 +1,10 @@
+package com.depromeet.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 테스트용의 Repository
+ */
+public interface MemberGoalRepository extends JpaRepository<MemberGoal, Long> {
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/ProfileIcon.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/ProfileIcon.java
@@ -1,0 +1,11 @@
+package com.depromeet.domain.member;
+
+/**
+ * 멤버의 프로필 아이콘 정보
+ * TODO 차후 시안이 나오면 결정
+ */
+public enum ProfileIcon {
+
+    RED, BLUE
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/repository/MemberRepositoryCustomImpl.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/repository/MemberRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 import static com.depromeet.domain.member.QMember.member;
+import static com.depromeet.domain.member.QMemberGoal.memberGoal;
 
 @RequiredArgsConstructor
 public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
@@ -21,7 +22,8 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
 
     @Override
     public Member findMemberById(Long id) {
-        return queryFactory.selectFrom(member)
+        return queryFactory.selectFrom(member).distinct()
+            .leftJoin(member.memberGoals, memberGoal).fetchJoin()
             .where(
                 member.id.eq(id)
             ).fetchOne();


### PR DESCRIPTION
1. 변경된 정책들

- 멤버는 여러 개의 아이콘 중 하나를 선택해서 사용할 수 있다. (일단 RED, BLUE로 모킹)
- 멤버는 n개의 목표를 설정할 수 있다. (현재 명상, 독서, 운동)
- 회원가입시, 이메일, 이름, 아이콘, 목표를 설정한다.

2. 코멘트
- 멤버의 목표와 멤버의 정보는 계속 같이 다닐 거 같아서 같은 애그리거트로 설정. (기상정보는 분리할 듯합니다)

3. 문서
(https://www.notion.so/API-2631f544769849f998b1abefd48e8537) 노션 페이지 참고