### PR TITLE
[Miracle-9] Enum 조회 성능을 높이기 위한 HashMap 캐싱 이용

### DIFF
--- a/miracle-domain/src/main/java/com/depromeet/domain/schedule/LoopType.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/schedule/LoopType.java
@@ -1,6 +1,7 @@
 package com.depromeet.domain.schedule;
 
-import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 public enum LoopType {
     NONE("NONE"),
@@ -14,14 +15,22 @@ public enum LoopType {
         this.text = text;
     }
 
-    public static LoopType of(String text) {
-        return Arrays.stream(values())
-            .filter(dayOfWeek -> dayOfWeek.text.equals(text))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException(String.format("Parameter is invalid. %s", text)));
-    }
-
     public String getText() {
         return text;
+    }
+
+    private final static Map<String, LoopType> cachingLoopType = new HashMap<>();
+
+    static {
+        for (LoopType loopType : values()) {
+            cachingLoopType.put(loopType.getText(), loopType);
+        }
+    }
+
+    public static LoopType of(String text) {
+        if (!cachingLoopType.containsKey(text)) {
+            throw new IllegalArgumentException(String.format("Parameter is invalid. %s", text));
+        }
+        return cachingLoopType.get(text);
     }
 }


### PR DESCRIPTION
1. 스트림을 여는 것은 비용이 큽니다. 그래서 캐싱해서 사용하면 성능상 이점이 있습니다~
참고 -> https://pjh3749.tistory.com/279

2.  Optional.ofNullable(cachingLoopType.get(text))
     .orElseThrow(() -> new IllegalArgumentException(String.format("Parameter is invalid. %s", text)));

이런식으로 Optional을 이용해도 되지만, 예외는 최대한 빨리 처리하는게 좋다고 생각해서 (제 멘토의 조언)
Optional을 이용하지 않고 아래처럼 처리하였습니다.