### PR TITLE
알람 도메인 구현 및 API 구현입니다

### DIFF
--- a/http/alarm.http
+++ b/http/alarm.http
@@ -1,0 +1,38 @@
+### 새로운 알림 스케쥴을 설정하는 API
+POST {{host}}/api/v1/alarm/schedule
+Authorization: Bearer {{AUTHORIZATION}}
+Content-Type: application/json
+
+{
+    "type": "WAKE_UP",
+    "description": "기상 알림",
+    "alarms": [
+        {
+            "dayOfTheWeek": "SUN",
+            "reminderTime": "09:00"
+        },
+        {
+            "dayOfTheWeek": "TUE",
+            "reminderTime": "10:00"
+        },
+        {
+            "dayOfTheWeek": "WED",
+            "reminderTime": "08:00"
+        }
+    ]
+}
+> {%
+client.global.set("ALARM_SCHEDULE_ID", response.body["data"]["id"])
+ %}
+
+
+### 회원의 알림 스케쥴 리스트를 불러오는 API
+GET {{host}}/api/v1/alarm/schedule/my
+Authorization: Bearer {{AUTHORIZATION}}
+
+
+### 특정 알림 스케쥴의 정보를 불러오는 API
+GET {{host}}/api/v1/alarm/schedule?alarmScheduleId={{ALARM_SCHEDULE_ID}}
+Authorization: Bearer {{AUTHORIZATION}}
+
+###

--- a/http/alarm.http
+++ b/http/alarm.http
@@ -35,4 +35,29 @@ Authorization: Bearer {{AUTHORIZATION}}
 GET {{host}}/api/v1/alarm/schedule?alarmScheduleId={{ALARM_SCHEDULE_ID}}
 Authorization: Bearer {{AUTHORIZATION}}
 
+### 특정 알림 스케쥴을 변경하는 API
+PUT {{host}}/api/v1/alarm/schedule
+Authorization: Bearer {{AUTHORIZATION}}
+Content-Type: application/json
+
+{
+    "alarmScheduleId": "{{ALARM_SCHEDULE_ID}}",
+    "type": "WAKE_UP",
+    "description": "기상 알람 서비스",
+    "alarms": [
+        {
+            "dayOfTheWeek": "WED",
+            "reminderTime": "08:00"
+        },
+        {
+            "dayOfTheWeek": "FRI",
+            "reminderTime": "15:00"
+        }
+    ]
+}
+
+### 특정 알림 스케쥴을 삭제하는 API
+DELETE {{host}}/api/v1/alarm/schedule?alarmScheduleId={{ALARM_SCHEDULE_ID}}
+Authorization: Bearer {{AUTHORIZATION}}
+
 ###

--- a/http/alarm.http
+++ b/http/alarm.http
@@ -1,11 +1,11 @@
-### 새로운 알림 스케쥴을 설정하는 API
+### 새로운 알림 스케쥴을 추가하는 API
 POST {{host}}/api/v1/alarm/schedule
 Authorization: Bearer {{AUTHORIZATION}}
 Content-Type: application/json
 
 {
     "type": "WAKE_UP",
-    "description": "기상 알림",
+    "description": "추가 설정한 기상 알람",
     "alarms": [
         {
             "dayOfTheWeek": "SUN",

--- a/http/member.http
+++ b/http/member.http
@@ -8,8 +8,10 @@ Content-Type: application/json
     "profileIcon": "RED",
     "goals": [
         "READING",
-        "EXERCISE"
-    ]
+        "EXERCISE",
+        "PROMISE"
+    ],
+    "wakeUpTime": "08:00"
 }
 > {%
 client.global.set("AUTHORIZATION", response.body["data"])

--- a/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmController.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmController.java
@@ -1,0 +1,41 @@
+package com.depromeet.controller.alarm;
+
+import com.depromeet.ApiResponse;
+import com.depromeet.config.resolver.LoginMember;
+import com.depromeet.config.session.MemberSession;
+import com.depromeet.service.alarm.AlarmService;
+import com.depromeet.service.alarm.dto.request.CreateAlarmScheduleRequest;
+import com.depromeet.service.alarm.dto.request.RetrieveAlarmScheduleRequest;
+import com.depromeet.service.alarm.dto.response.AlarmScheduleInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class AlarmController {
+
+    private final AlarmService alarmService;
+
+    @PostMapping("/api/v1/alarm/schedule")
+    public ApiResponse<AlarmScheduleInfoResponse> createAlarmSchedule(@Valid @RequestBody CreateAlarmScheduleRequest request,
+                                                                      @LoginMember MemberSession memberSession) {
+        return ApiResponse.of(alarmService.createAlarmSchedule(request, memberSession.getMemberId()));
+    }
+
+    @GetMapping("/api/v1/alarm/schedule/my")
+    public ApiResponse<List<AlarmScheduleInfoResponse>> retrieveAlarmSchedules(@LoginMember MemberSession memberSession) {
+        return ApiResponse.of(alarmService.retrieveAlarmSchedules(memberSession.getMemberId()));
+    }
+
+    @GetMapping("/api/v1/alarm/schedule")
+    public ApiResponse<AlarmScheduleInfoResponse> retrieveAlarmSchedule(@Valid RetrieveAlarmScheduleRequest request, @LoginMember MemberSession memberSession) {
+        return ApiResponse.of(alarmService.retrieveAlarmSchedule(request, memberSession.getMemberId()));
+    }
+
+}

--- a/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmController.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmController.java
@@ -5,11 +5,15 @@ import com.depromeet.config.resolver.LoginMember;
 import com.depromeet.config.session.MemberSession;
 import com.depromeet.service.alarm.AlarmService;
 import com.depromeet.service.alarm.dto.request.CreateAlarmScheduleRequest;
+import com.depromeet.service.alarm.dto.request.DeleteAlarmScheduleRequest;
 import com.depromeet.service.alarm.dto.request.RetrieveAlarmScheduleRequest;
+import com.depromeet.service.alarm.dto.request.UpdateAlarmScheduleRequest;
 import com.depromeet.service.alarm.dto.response.AlarmScheduleInfoResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -45,6 +49,23 @@ public class AlarmController {
     @GetMapping("/api/v1/alarm/schedule")
     public ApiResponse<AlarmScheduleInfoResponse> retrieveAlarmSchedule(@Valid RetrieveAlarmScheduleRequest request, @LoginMember MemberSession memberSession) {
         return ApiResponse.of(alarmService.retrieveAlarmSchedule(request, memberSession.getMemberId()));
+    }
+
+    /**
+     * 특정 알림 스케쥴을 변경하는 API
+     */
+    @PutMapping("/api/v1/alarm/schedule")
+    public ApiResponse<AlarmScheduleInfoResponse> updateAlarmSchedule(@Valid @RequestBody UpdateAlarmScheduleRequest request, @LoginMember MemberSession memberSession) {
+        return ApiResponse.of(alarmService.updateAlarmSchedule(request, memberSession.getMemberId()));
+    }
+
+    /**
+     * 특정 알림 스케쥴을 삭제하는 API
+     */
+    @DeleteMapping("/api/v1/alarm/schedule")
+    public ApiResponse<String> deleteAlarmSchedule(@Valid DeleteAlarmScheduleRequest request, @LoginMember MemberSession memberSession) {
+        alarmService.deleteAlarmSchedule(request, memberSession.getMemberId());
+        return ApiResponse.SUCCESS;
     }
 
 }

--- a/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmController.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmController.java
@@ -40,7 +40,7 @@ public class AlarmController {
     }
 
     /**
-     * 특정 앎림 스케쥴의 정보를 불러오는 API
+     * 특정 알림 스케쥴의 정보를 불러오는 API
      */
     @GetMapping("/api/v1/alarm/schedule")
     public ApiResponse<AlarmScheduleInfoResponse> retrieveAlarmSchedule(@Valid RetrieveAlarmScheduleRequest request, @LoginMember MemberSession memberSession) {

--- a/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmController.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmController.java
@@ -22,17 +22,26 @@ public class AlarmController {
 
     private final AlarmService alarmService;
 
+    /**
+     * 새로운 알림 스케쥴을 생성하는 API
+     */
     @PostMapping("/api/v1/alarm/schedule")
     public ApiResponse<AlarmScheduleInfoResponse> createAlarmSchedule(@Valid @RequestBody CreateAlarmScheduleRequest request,
                                                                       @LoginMember MemberSession memberSession) {
         return ApiResponse.of(alarmService.createAlarmSchedule(request, memberSession.getMemberId()));
     }
 
+    /**
+     * 회원의 알림 스케쥴 리스트를 불러오는 API
+     */
     @GetMapping("/api/v1/alarm/schedule/my")
     public ApiResponse<List<AlarmScheduleInfoResponse>> retrieveAlarmSchedules(@LoginMember MemberSession memberSession) {
         return ApiResponse.of(alarmService.retrieveAlarmSchedules(memberSession.getMemberId()));
     }
 
+    /**
+     * 특정 앎림 스케쥴의 정보를 불러오는 API
+     */
     @GetMapping("/api/v1/alarm/schedule")
     public ApiResponse<AlarmScheduleInfoResponse> retrieveAlarmSchedule(@Valid RetrieveAlarmScheduleRequest request, @LoginMember MemberSession memberSession) {
         return ApiResponse.of(alarmService.retrieveAlarmSchedule(request, memberSession.getMemberId()));

--- a/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmEventListener.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmEventListener.java
@@ -1,0 +1,20 @@
+package com.depromeet.controller.alarm;
+
+import com.depromeet.event.alarm.NewMemberRegisteredEvent;
+import com.depromeet.service.alarm.AlarmService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class AlarmEventListener {
+
+    private final AlarmService alarmService;
+
+    @EventListener
+    public void createDefaultWakeUpAlarm(NewMemberRegisteredEvent event) {
+        alarmService.createDefaultWakeUpAlarmSchedule(event.getMemberId(), event.getWakeUpTime());
+    }
+
+}

--- a/miracle-api/src/main/java/com/depromeet/event/alarm/NewMemberRegisteredEvent.java
+++ b/miracle-api/src/main/java/com/depromeet/event/alarm/NewMemberRegisteredEvent.java
@@ -1,0 +1,21 @@
+package com.depromeet.event.alarm;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class NewMemberRegisteredEvent {
+
+    private final Long memberId;
+
+    private final LocalTime wakeUpTime;
+
+    public static NewMemberRegisteredEvent of(Long memberId, LocalTime wakeUpTime) {
+        return new NewMemberRegisteredEvent(memberId, wakeUpTime);
+    }
+
+}

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
@@ -35,7 +35,7 @@ public class AlarmService {
     @Transactional
     public AlarmScheduleInfoResponse retrieveAlarmSchedule(RetrieveAlarmScheduleRequest request, Long memberId) {
         AlarmSchedule alarmSchedule = AlarmServiceUtils.findAlarmScheduleById(alarmScheduleRepository, request.getAlarmScheduleId());
-        AlarmServiceUtils.validateHasOwner(alarmSchedule, memberId);
+        alarmSchedule.validateMemberHasOwner(memberId);
         return AlarmScheduleInfoResponse.of(alarmSchedule);
     }
 

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
@@ -32,7 +32,7 @@ public class AlarmService {
             .collect(Collectors.toList());
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public AlarmScheduleInfoResponse retrieveAlarmSchedule(RetrieveAlarmScheduleRequest request, Long memberId) {
         AlarmSchedule alarmSchedule = AlarmServiceUtils.findAlarmScheduleById(alarmScheduleRepository, request.getAlarmScheduleId());
         alarmSchedule.validateMemberHasOwner(memberId);

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
@@ -1,7 +1,7 @@
 package com.depromeet.service.alarm;
 
 import com.depromeet.domain.alarm.AlarmSchedule;
-import com.depromeet.domain.alarm.AlarmScheduleScheduleRepository;
+import com.depromeet.domain.alarm.AlarmScheduleRepository;
 import com.depromeet.service.alarm.dto.request.CreateAlarmScheduleRequest;
 import com.depromeet.service.alarm.dto.request.DeleteAlarmScheduleRequest;
 import com.depromeet.service.alarm.dto.request.RetrieveAlarmScheduleRequest;
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,7 +19,12 @@ import java.util.stream.Collectors;
 @Service
 public class AlarmService {
 
-    private final AlarmScheduleScheduleRepository alarmScheduleRepository;
+    private final AlarmScheduleRepository alarmScheduleRepository;
+
+    @Transactional
+    public void createDefaultWakeUpAlarmSchedule(Long memberId, LocalTime wakeUpTime) {
+        alarmScheduleRepository.save(AlarmSchedule.defaultWakeUpAlarmSchedule(memberId, wakeUpTime));
+    }
 
     @Transactional
     public AlarmScheduleInfoResponse createAlarmSchedule(CreateAlarmScheduleRequest request, Long memberId) {

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
@@ -35,7 +35,7 @@ public class AlarmService {
     @Transactional
     public AlarmScheduleInfoResponse retrieveAlarmSchedule(RetrieveAlarmScheduleRequest request, Long memberId) {
         AlarmSchedule alarmSchedule = AlarmServiceUtils.findAlarmScheduleById(alarmScheduleRepository, request.getAlarmScheduleId());
-        AlarmServiceUtils.validateOwner(alarmSchedule, memberId);
+        AlarmServiceUtils.validateHasOwner(alarmSchedule, memberId);
         return AlarmScheduleInfoResponse.of(alarmSchedule);
     }
 

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
@@ -36,15 +36,13 @@ public class AlarmService {
 
     @Transactional(readOnly = true)
     public AlarmScheduleInfoResponse retrieveAlarmSchedule(RetrieveAlarmScheduleRequest request, Long memberId) {
-        AlarmSchedule alarmSchedule = AlarmServiceUtils.findAlarmScheduleById(alarmScheduleRepository, request.getAlarmScheduleId());
-        alarmSchedule.validateMemberHasOwner(memberId);
+        AlarmSchedule alarmSchedule = AlarmServiceUtils.findAlarmScheduleByIdAndMemberId(alarmScheduleRepository, request.getAlarmScheduleId(), memberId);
         return AlarmScheduleInfoResponse.of(alarmSchedule);
     }
 
     @Transactional
     public AlarmScheduleInfoResponse updateAlarmSchedule(UpdateAlarmScheduleRequest request, Long memberId) {
-        AlarmSchedule findAlarmSchedule = AlarmServiceUtils.findAlarmScheduleById(alarmScheduleRepository, request.getAlarmScheduleId());
-        findAlarmSchedule.validateMemberHasOwner(memberId);
+        AlarmSchedule findAlarmSchedule = AlarmServiceUtils.findAlarmScheduleByIdAndMemberId(alarmScheduleRepository, request.getAlarmScheduleId(), memberId);
         findAlarmSchedule.updateAlarmScheduleInfo(request.getType(), request.getDescription());
 
         AlarmSchedule targetAlarms = request.toEntity(memberId);
@@ -57,8 +55,7 @@ public class AlarmService {
 
     @Transactional
     public void deleteAlarmSchedule(DeleteAlarmScheduleRequest request, Long memberId) {
-        AlarmSchedule alarmSchedule = AlarmServiceUtils.findAlarmScheduleById(alarmScheduleRepository, request.getAlarmScheduleId());
-        alarmSchedule.validateMemberHasOwner(memberId);
+        AlarmSchedule alarmSchedule = AlarmServiceUtils.findAlarmScheduleByIdAndMemberId(alarmScheduleRepository, request.getAlarmScheduleId(), memberId);
         alarmScheduleRepository.delete(alarmSchedule);
     }
 

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
@@ -3,7 +3,9 @@ package com.depromeet.service.alarm;
 import com.depromeet.domain.alarm.AlarmSchedule;
 import com.depromeet.domain.alarm.AlarmScheduleScheduleRepository;
 import com.depromeet.service.alarm.dto.request.CreateAlarmScheduleRequest;
+import com.depromeet.service.alarm.dto.request.DeleteAlarmScheduleRequest;
 import com.depromeet.service.alarm.dto.request.RetrieveAlarmScheduleRequest;
+import com.depromeet.service.alarm.dto.request.UpdateAlarmScheduleRequest;
 import com.depromeet.service.alarm.dto.response.AlarmScheduleInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,6 +39,27 @@ public class AlarmService {
         AlarmSchedule alarmSchedule = AlarmServiceUtils.findAlarmScheduleById(alarmScheduleRepository, request.getAlarmScheduleId());
         alarmSchedule.validateMemberHasOwner(memberId);
         return AlarmScheduleInfoResponse.of(alarmSchedule);
+    }
+
+    @Transactional
+    public AlarmScheduleInfoResponse updateAlarmSchedule(UpdateAlarmScheduleRequest request, Long memberId) {
+        AlarmSchedule findAlarmSchedule = AlarmServiceUtils.findAlarmScheduleById(alarmScheduleRepository, request.getAlarmScheduleId());
+        findAlarmSchedule.validateMemberHasOwner(memberId);
+        findAlarmSchedule.updateAlarmScheduleInfo(request.getType(), request.getDescription());
+
+        AlarmSchedule targetAlarms = request.toEntity(memberId);
+        if (findAlarmSchedule.hasSameAlarms(targetAlarms)) {
+            return AlarmScheduleInfoResponse.of(findAlarmSchedule);
+        }
+        findAlarmSchedule.updateAlarms(request.toAlarmsEntity());
+        return AlarmScheduleInfoResponse.of(findAlarmSchedule);
+    }
+
+    @Transactional
+    public void deleteAlarmSchedule(DeleteAlarmScheduleRequest request, Long memberId) {
+        AlarmSchedule alarmSchedule = AlarmServiceUtils.findAlarmScheduleById(alarmScheduleRepository, request.getAlarmScheduleId());
+        alarmSchedule.validateMemberHasOwner(memberId);
+        alarmScheduleRepository.delete(alarmSchedule);
     }
 
 }

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
@@ -1,0 +1,42 @@
+package com.depromeet.service.alarm;
+
+import com.depromeet.domain.alarm.AlarmSchedule;
+import com.depromeet.domain.alarm.AlarmScheduleScheduleRepository;
+import com.depromeet.service.alarm.dto.request.CreateAlarmScheduleRequest;
+import com.depromeet.service.alarm.dto.request.RetrieveAlarmScheduleRequest;
+import com.depromeet.service.alarm.dto.response.AlarmScheduleInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class AlarmService {
+
+    private final AlarmScheduleScheduleRepository alarmScheduleRepository;
+
+    @Transactional
+    public AlarmScheduleInfoResponse createAlarmSchedule(CreateAlarmScheduleRequest request, Long memberId) {
+        AlarmSchedule alarmSchedule = alarmScheduleRepository.save(request.toEntity(memberId));
+        return AlarmScheduleInfoResponse.of(alarmSchedule);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AlarmScheduleInfoResponse> retrieveAlarmSchedules(Long memberId) {
+        List<AlarmSchedule> alarmSchedules = alarmScheduleRepository.findAlarmSchedulesByMemberId(memberId);
+        return alarmSchedules.stream()
+            .map(AlarmScheduleInfoResponse::of)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public AlarmScheduleInfoResponse retrieveAlarmSchedule(RetrieveAlarmScheduleRequest request, Long memberId) {
+        AlarmSchedule alarmSchedule = AlarmServiceUtils.findAlarmScheduleById(alarmScheduleRepository, request.getAlarmScheduleId());
+        AlarmServiceUtils.validateOwner(alarmSchedule, memberId);
+        return AlarmScheduleInfoResponse.of(alarmSchedule);
+    }
+
+}

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
@@ -11,7 +11,7 @@ class AlarmServiceUtils {
     static AlarmSchedule findAlarmScheduleByIdAndMemberId(AlarmScheduleScheduleRepository alarmScheduleScheduleRepository, Long alarmScheduleId, Long memberId) {
         AlarmSchedule alarmSchedule = alarmScheduleScheduleRepository.findAlarmScheduleByIdAndMemberId(alarmScheduleId, memberId);
         if (alarmSchedule == null) {
-            throw new IllegalArgumentException(String.format("id가 (%s)인 AlarmSchedule 은 존재하지 않습니다", alarmScheduleId));
+            throw new IllegalArgumentException(String.format("멤버 (%s) 에게 AlarmSchedule (%s) 은 존재하지 않습니다", memberId, alarmScheduleId));
         }
         return alarmSchedule;
     }

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
@@ -16,7 +16,7 @@ class AlarmServiceUtils {
         return alarmSchedule;
     }
 
-    static void validateOwner(AlarmSchedule alarmSchedule, Long memberId) {
+    static void validateHasOwner(AlarmSchedule alarmSchedule, Long memberId) {
         if (!alarmSchedule.isOwner(memberId)) {
             throw new IllegalArgumentException(String.format("AlarmSchedule (%s)은 멤버 (%s)의 알림 스케쥴이 아닙니다", alarmSchedule.getId(), memberId));
         }

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
@@ -16,9 +16,4 @@ class AlarmServiceUtils {
         return alarmSchedule;
     }
 
-    static void validateHasOwner(AlarmSchedule alarmSchedule, Long memberId) {
-        if (!alarmSchedule.isOwner(memberId)) {
-            throw new IllegalArgumentException(String.format("AlarmSchedule (%s)은 멤버 (%s)의 알림 스케쥴이 아닙니다", alarmSchedule.getId(), memberId));
-        }
-    }
 }

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
@@ -1,15 +1,15 @@
 package com.depromeet.service.alarm;
 
 import com.depromeet.domain.alarm.AlarmSchedule;
-import com.depromeet.domain.alarm.AlarmScheduleScheduleRepository;
+import com.depromeet.domain.alarm.AlarmScheduleRepository;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 class AlarmServiceUtils {
 
-    static AlarmSchedule findAlarmScheduleByIdAndMemberId(AlarmScheduleScheduleRepository alarmScheduleScheduleRepository, Long alarmScheduleId, Long memberId) {
-        AlarmSchedule alarmSchedule = alarmScheduleScheduleRepository.findAlarmScheduleByIdAndMemberId(alarmScheduleId, memberId);
+    static AlarmSchedule findAlarmScheduleByIdAndMemberId(AlarmScheduleRepository alarmScheduleRepository, Long alarmScheduleId, Long memberId) {
+        AlarmSchedule alarmSchedule = alarmScheduleRepository.findAlarmScheduleByIdAndMemberId(alarmScheduleId, memberId);
         if (alarmSchedule == null) {
             throw new IllegalArgumentException(String.format("멤버 (%s) 에게 AlarmSchedule (%s) 은 존재하지 않습니다", memberId, alarmScheduleId));
         }

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
@@ -8,8 +8,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 class AlarmServiceUtils {
 
-    static AlarmSchedule findAlarmScheduleById(AlarmScheduleScheduleRepository alarmScheduleScheduleRepository, Long alarmScheduleId) {
-        AlarmSchedule alarmSchedule = alarmScheduleScheduleRepository.findAlarmScheduleById(alarmScheduleId);
+    static AlarmSchedule findAlarmScheduleByIdAndMemberId(AlarmScheduleScheduleRepository alarmScheduleScheduleRepository, Long alarmScheduleId, Long memberId) {
+        AlarmSchedule alarmSchedule = alarmScheduleScheduleRepository.findAlarmScheduleByIdAndMemberId(alarmScheduleId, memberId);
         if (alarmSchedule == null) {
             throw new IllegalArgumentException(String.format("id가 (%s)인 AlarmSchedule 은 존재하지 않습니다", alarmScheduleId));
         }

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
@@ -1,0 +1,24 @@
+package com.depromeet.service.alarm;
+
+import com.depromeet.domain.alarm.AlarmSchedule;
+import com.depromeet.domain.alarm.AlarmScheduleScheduleRepository;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+class AlarmServiceUtils {
+
+    static AlarmSchedule findAlarmScheduleById(AlarmScheduleScheduleRepository alarmScheduleScheduleRepository, Long alarmScheduleId) {
+        AlarmSchedule alarmSchedule = alarmScheduleScheduleRepository.findAlarmScheduleById(alarmScheduleId);
+        if (alarmSchedule == null) {
+            throw new IllegalArgumentException(String.format("id가 (%s)인 AlarmSchedule 은 존재하지 않습니다", alarmScheduleId));
+        }
+        return alarmSchedule;
+    }
+
+    static void validateOwner(AlarmSchedule alarmSchedule, Long memberId) {
+        if (!alarmSchedule.isOwner(memberId)) {
+            throw new IllegalArgumentException(String.format("AlarmSchedule (%s)은 멤버 (%s)의 알림 스케쥴이 아닙니다", alarmSchedule.getId(), memberId));
+        }
+    }
+}

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/AlarmRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/AlarmRequest.java
@@ -1,7 +1,7 @@
 package com.depromeet.service.alarm.dto.request;
 
 import com.depromeet.domain.alarm.Alarm;
-import com.depromeet.domain.alarm.DayOfTheWeek;
+import com.depromeet.domain.common.DayOfTheWeek;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/AlarmRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/AlarmRequest.java
@@ -11,7 +11,7 @@ import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor
-public class CreateAlarmRequest {
+public class AlarmRequest {
 
     @NotNull
     private DayOfTheWeek dayOfTheWeek;
@@ -20,7 +20,7 @@ public class CreateAlarmRequest {
     private LocalTime reminderTime;
 
     @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
-    public CreateAlarmRequest(DayOfTheWeek dayOfTheWeek, LocalTime reminderTime) {
+    public AlarmRequest(DayOfTheWeek dayOfTheWeek, LocalTime reminderTime) {
         this.dayOfTheWeek = dayOfTheWeek;
         this.reminderTime = reminderTime;
     }

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/CreateAlarmRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/CreateAlarmRequest.java
@@ -6,14 +6,17 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
 import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor
 public class CreateAlarmRequest {
 
+    @NotNull
     private DayOfTheWeek dayOfTheWeek;
 
+    @NotNull
     private LocalTime reminderTime;
 
     @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/CreateAlarmRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/CreateAlarmRequest.java
@@ -1,0 +1,29 @@
+package com.depromeet.service.alarm.dto.request;
+
+import com.depromeet.domain.alarm.Alarm;
+import com.depromeet.domain.alarm.DayOfTheWeek;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class CreateAlarmRequest {
+
+    private DayOfTheWeek dayOfTheWeek;
+
+    private LocalTime reminderTime;
+
+    @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
+    public CreateAlarmRequest(DayOfTheWeek dayOfTheWeek, LocalTime reminderTime) {
+        this.dayOfTheWeek = dayOfTheWeek;
+        this.reminderTime = reminderTime;
+    }
+
+    Alarm toEntity() {
+        return Alarm.newInstance(dayOfTheWeek, reminderTime);
+    }
+
+}

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/CreateAlarmScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/CreateAlarmScheduleRequest.java
@@ -1,0 +1,39 @@
+package com.depromeet.service.alarm.dto.request;
+
+import com.depromeet.domain.alarm.Alarm;
+import com.depromeet.domain.alarm.AlarmSchedule;
+import com.depromeet.domain.alarm.AlarmType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+public class CreateAlarmScheduleRequest {
+
+    private String description;
+
+    private AlarmType type;
+
+    private List<CreateAlarmRequest> alarms;
+
+    @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
+    public CreateAlarmScheduleRequest(String description, AlarmType type, List<CreateAlarmRequest> alarms) {
+        this.description = description;
+        this.type = type;
+        this.alarms = alarms;
+    }
+
+    public AlarmSchedule toEntity(Long memberId) {
+        List<Alarm> alarmList = alarms.stream()
+            .map(CreateAlarmRequest::toEntity)
+            .collect(Collectors.toList());
+        AlarmSchedule alarmSchedule = AlarmSchedule.newInstance(memberId, type, description);
+        alarmSchedule.addAlarms(alarmList);
+        return alarmSchedule;
+    }
+
+}

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/CreateAlarmScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/CreateAlarmScheduleRequest.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -16,8 +17,10 @@ public class CreateAlarmScheduleRequest {
 
     private String description;
 
+    @NotNull
     private AlarmType type;
 
+    @NotNull
     private List<CreateAlarmRequest> alarms;
 
     @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/DeleteAlarmScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/DeleteAlarmScheduleRequest.java
@@ -1,0 +1,23 @@
+package com.depromeet.service.alarm.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+public class DeleteAlarmScheduleRequest {
+
+    @NotNull
+    private Long alarmScheduleId;
+
+    private DeleteAlarmScheduleRequest(Long alarmScheduleId) {
+        this.alarmScheduleId = alarmScheduleId;
+    }
+
+    public static DeleteAlarmScheduleRequest testInstance(Long alarmScheduleId) {
+        return new DeleteAlarmScheduleRequest(alarmScheduleId);
+    }
+
+}

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/RetrieveAlarmScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/RetrieveAlarmScheduleRequest.java
@@ -1,0 +1,20 @@
+package com.depromeet.service.alarm.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RetrieveAlarmScheduleRequest {
+
+    private Long alarmScheduleId;
+
+    private RetrieveAlarmScheduleRequest(Long alarmScheduleId) {
+        this.alarmScheduleId = alarmScheduleId;
+    }
+
+    public static RetrieveAlarmScheduleRequest of(Long alarmScheduleId) {
+        return new RetrieveAlarmScheduleRequest(alarmScheduleId);
+    }
+
+}

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/RetrieveAlarmScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/RetrieveAlarmScheduleRequest.java
@@ -3,10 +3,13 @@ package com.depromeet.service.alarm.dto.request;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 @NoArgsConstructor
 public class RetrieveAlarmScheduleRequest {
 
+    @NotNull
     private Long alarmScheduleId;
 
     private RetrieveAlarmScheduleRequest(Long alarmScheduleId) {

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/UpdateAlarmScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/UpdateAlarmScheduleRequest.java
@@ -13,20 +13,24 @@ import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
-public class CreateAlarmScheduleRequest {
+public class UpdateAlarmScheduleRequest {
 
-    private String description;
+    @NotNull
+    private Long alarmScheduleId;
 
     @NotNull
     private AlarmType type;
+
+    private String description;
 
     @NotNull
     private List<AlarmRequest> alarms;
 
     @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
-    public CreateAlarmScheduleRequest(String description, AlarmType type, List<AlarmRequest> alarms) {
-        this.description = description;
+    public UpdateAlarmScheduleRequest(Long alarmScheduleId, AlarmType type, String description, List<AlarmRequest> alarms) {
+        this.alarmScheduleId = alarmScheduleId;
         this.type = type;
+        this.description = description;
         this.alarms = alarms;
     }
 
@@ -37,6 +41,12 @@ public class CreateAlarmScheduleRequest {
         AlarmSchedule alarmSchedule = AlarmSchedule.newInstance(memberId, type, description);
         alarmSchedule.addAlarms(alarmList);
         return alarmSchedule;
+    }
+
+    public List<Alarm> toAlarmsEntity() {
+        return alarms.stream()
+            .map(AlarmRequest::toEntity)
+            .collect(Collectors.toList());
     }
 
 }

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/response/AlarmInfoResponse.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/response/AlarmInfoResponse.java
@@ -1,7 +1,7 @@
 package com.depromeet.service.alarm.dto.response;
 
 import com.depromeet.domain.alarm.Alarm;
-import com.depromeet.domain.alarm.DayOfTheWeek;
+import com.depromeet.domain.common.DayOfTheWeek;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/response/AlarmInfoResponse.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/response/AlarmInfoResponse.java
@@ -1,0 +1,25 @@
+package com.depromeet.service.alarm.dto.response;
+
+import com.depromeet.domain.alarm.Alarm;
+import com.depromeet.domain.alarm.DayOfTheWeek;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalTime;
+
+@ToString
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class AlarmInfoResponse {
+
+    private final DayOfTheWeek dayOfTheWeek;
+
+    private final LocalTime reminderTime;
+
+    public static AlarmInfoResponse of(Alarm alarm) {
+        return new AlarmInfoResponse(alarm.getDayOfTheWeek(), alarm.getReminderTime());
+    }
+
+}

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/response/AlarmScheduleInfoResponse.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/response/AlarmScheduleInfoResponse.java
@@ -1,0 +1,33 @@
+package com.depromeet.service.alarm.dto.response;
+
+import com.depromeet.domain.alarm.AlarmSchedule;
+import com.depromeet.domain.alarm.AlarmType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ToString
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class AlarmScheduleInfoResponse {
+
+    private final Long id;
+
+    private final AlarmType type;
+
+    private final String description;
+
+    private final List<AlarmInfoResponse> alarms;
+
+    public static AlarmScheduleInfoResponse of(AlarmSchedule alarmSchedule) {
+        List<AlarmInfoResponse> alarmInfoResponses = alarmSchedule.getAlarms().stream()
+            .map(AlarmInfoResponse::of)
+            .collect(Collectors.toList());
+        return new AlarmScheduleInfoResponse(alarmSchedule.getId(), alarmSchedule.getType(), alarmSchedule.getDescription(), alarmInfoResponses);
+    }
+
+}

--- a/miracle-api/src/main/java/com/depromeet/service/member/MemberService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/MemberService.java
@@ -2,25 +2,28 @@ package com.depromeet.service.member;
 
 import com.depromeet.domain.member.Member;
 import com.depromeet.domain.member.MemberRepository;
+import com.depromeet.event.alarm.NewMemberRegisteredEvent;
 import com.depromeet.service.member.dto.request.SignUpMemberRequest;
 import com.depromeet.service.member.dto.request.UpdateMemberGoalsRequest;
 import com.depromeet.service.member.dto.request.UpdateMemberInfoRequest;
 import com.depromeet.service.member.dto.response.MemberInfoResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 
 @RequiredArgsConstructor
 @Service
 public class MemberService {
 
+    private final ApplicationEventPublisher eventPublisher;
     private final MemberRepository memberRepository;
 
     @Transactional
     public Long signUpMember(SignUpMemberRequest request) {
         MemberServiceUtils.validateNonExistMember(memberRepository, request.getEmail());
         Member newMember = memberRepository.save(request.toEntity());
+        eventPublisher.publishEvent(NewMemberRegisteredEvent.of(newMember.getId(), request.getWakeUpTime()));
         return newMember.getId();
     }
 

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/request/SignUpMemberRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/request/SignUpMemberRequest.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.time.LocalTime;
 import java.util.List;
 
 @Getter
@@ -25,14 +27,19 @@ public class SignUpMemberRequest {
     private ProfileIcon profileIcon;
 
     @NotNull
+    @Size(max = 3)
     private List<Category> goals;
 
+    @NotNull
+    private LocalTime wakeUpTime;
+
     @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
-    public SignUpMemberRequest(String email, String name, ProfileIcon profileIcon, List<Category> goals) {
+    public SignUpMemberRequest(String email, String name, ProfileIcon profileIcon, List<Category> goals, LocalTime wakeUpTime) {
         this.email = email;
         this.name = name;
         this.profileIcon = profileIcon;
         this.goals = goals;
+        this.wakeUpTime = wakeUpTime;
     }
 
     public Member toEntity() {

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberGoalsRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberGoalsRequest.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @Getter
@@ -12,6 +13,7 @@ import java.util.List;
 public class UpdateMemberGoalsRequest {
 
     @NotNull
+    @Size(max = 3)
     private List<Category> goals;
 
     private UpdateMemberGoalsRequest(List<Category> goals) {

--- a/miracle-api/src/test/java/com/depromeet/service/MemberSetup.java
+++ b/miracle-api/src/test/java/com/depromeet/service/MemberSetup.java
@@ -1,0 +1,29 @@
+package com.depromeet.service;
+
+import com.depromeet.domain.member.Member;
+import com.depromeet.domain.member.MemberCreator;
+import com.depromeet.domain.member.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public abstract class MemberSetup {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    protected static Long memberId;
+
+    @BeforeEach
+    void setup() {
+        Member member = MemberCreator.create("will.seungho@gmail.com");
+        memberRepository.save(member);
+        memberId = member.getId();
+    }
+
+    protected void cleanup() {
+        memberRepository.deleteAll();
+    }
+
+}

--- a/miracle-api/src/test/java/com/depromeet/service/alarm/AlarmServiceTest.java
+++ b/miracle-api/src/test/java/com/depromeet/service/alarm/AlarmServiceTest.java
@@ -1,0 +1,181 @@
+package com.depromeet.service.alarm;
+
+import com.depromeet.domain.alarm.Alarm;
+import com.depromeet.domain.alarm.AlarmCreator;
+import com.depromeet.domain.alarm.AlarmRepository;
+import com.depromeet.domain.alarm.AlarmSchedule;
+import com.depromeet.domain.alarm.AlarmScheduleCreator;
+import com.depromeet.domain.alarm.AlarmScheduleScheduleRepository;
+import com.depromeet.domain.alarm.AlarmType;
+import com.depromeet.domain.alarm.DayOfTheWeek;
+import com.depromeet.service.MemberSetup;
+import com.depromeet.service.alarm.dto.request.CreateAlarmRequest;
+import com.depromeet.service.alarm.dto.request.CreateAlarmScheduleRequest;
+import com.depromeet.service.alarm.dto.request.RetrieveAlarmScheduleRequest;
+import com.depromeet.service.alarm.dto.response.AlarmScheduleInfoResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+class AlarmServiceTest extends MemberSetup {
+
+    @Autowired
+    private AlarmService alarmService;
+
+    @Autowired
+    private AlarmScheduleScheduleRepository alarmScheduleScheduleRepository;
+
+    @Autowired
+    private AlarmRepository alarmRepository;
+
+    @AfterEach
+    void cleanUp() {
+        super.cleanup();
+        alarmRepository.deleteAllInBatch();
+        alarmScheduleScheduleRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 새로운_알림을_설정하면_알림_스케쥴이_생성된다() {
+        // given
+        String description = "기상 알림";
+        AlarmType type = AlarmType.WAKE_UP;
+
+        CreateAlarmScheduleRequest request = CreateAlarmScheduleRequest.testBuilder()
+            .description(description)
+            .type(type)
+            .alarms(Collections.emptyList())
+            .build();
+
+        // when
+        alarmService.createAlarmSchedule(request, memberId);
+
+        // then
+        List<AlarmSchedule> alarmSchedules = alarmScheduleScheduleRepository.findAll();
+        assertThat(alarmSchedules).hasSize(1);
+        assertAlarmSchedule(alarmSchedules.get(0), description, type);
+    }
+
+    @Test
+    void 새로운_알림을_설정하면_알림_스케쥴에_알림이_생성된다() {
+        // given
+        DayOfTheWeek dayOfTheWeek = DayOfTheWeek.MON;
+        LocalTime reminderTime = LocalTime.of(9, 0);
+
+        CreateAlarmRequest alarmRequest = CreateAlarmRequest.testBuilder()
+            .dayOfTheWeek(dayOfTheWeek)
+            .reminderTime(reminderTime)
+            .build();
+
+        CreateAlarmScheduleRequest request = CreateAlarmScheduleRequest.testBuilder()
+            .type(AlarmType.WAKE_UP)
+            .alarms(Collections.singletonList(alarmRequest))
+            .build();
+
+        // when
+        alarmService.createAlarmSchedule(request, memberId);
+
+        // then
+        List<Alarm> alarms = alarmRepository.findAll();
+        assertThat(alarms).hasSize(1);
+        assertAlarm(alarms.get(0), dayOfTheWeek, reminderTime);
+    }
+
+    @Test
+    void 회원의_알림_스케쥴_리스트_정보를_불러온다() {
+        // given
+        String description = "알림 스케쥴";
+        AlarmType type = AlarmType.WAKE_UP;
+
+        AlarmSchedule alarmSchedule = AlarmScheduleCreator.createAlarmSchedule(memberId, type, description);
+        Alarm alarm1 = AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(8, 0));
+        Alarm alarm2 = AlarmCreator.createAlarm(DayOfTheWeek.TUE, LocalTime.of(9, 0));
+        alarmSchedule.addAlarms(Arrays.asList(alarm1, alarm2));
+        alarmScheduleScheduleRepository.save(alarmSchedule);
+
+        // when
+        List<AlarmScheduleInfoResponse> responses = alarmService.retrieveAlarmSchedules(memberId);
+
+        // then
+        assertAll(
+            () -> assertThat(responses).hasSize(1),
+            () -> assertAlarmScheduleInfoResponse(responses.get(0), alarmSchedule.getId(), type, description),
+            () -> assertThat(responses.get(0).getAlarms()).hasSize(2),
+            () -> assertThat(responses.get(0).getAlarms()).extracting("dayOfTheWeek").containsExactly(DayOfTheWeek.MON, DayOfTheWeek.TUE),
+            () -> assertThat(responses.get(0).getAlarms()).extracting("reminderTime").containsExactly(LocalTime.of(8, 0), LocalTime.of(9, 0))
+        );
+    }
+
+    @Test
+    void 특정_알림_스케쥴의_정보를_불러온다() {
+        // given
+        String description = "알림 스케쥴";
+        AlarmType type = AlarmType.WAKE_UP;
+
+        AlarmSchedule alarmSchedule = AlarmScheduleCreator.createAlarmSchedule(memberId, type, description);
+        Alarm alarm1 = AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(8, 0));
+        Alarm alarm2 = AlarmCreator.createAlarm(DayOfTheWeek.TUE, LocalTime.of(9, 0));
+        alarmSchedule.addAlarms(Arrays.asList(alarm1, alarm2));
+        alarmScheduleScheduleRepository.save(alarmSchedule);
+
+        RetrieveAlarmScheduleRequest request = RetrieveAlarmScheduleRequest.of(alarmSchedule.getId());
+
+        // when
+        AlarmScheduleInfoResponse response = alarmService.retrieveAlarmSchedule(request, memberId);
+
+        // then
+        assertAll(
+            () -> assertAlarmScheduleInfoResponse(response, alarmSchedule.getId(), type, description),
+            () -> assertThat(response.getAlarms()).hasSize(2),
+            () -> assertThat(response.getAlarms()).extracting("dayOfTheWeek").containsExactly(DayOfTheWeek.MON, DayOfTheWeek.TUE),
+            () -> assertThat(response.getAlarms()).extracting("reminderTime").containsExactly(LocalTime.of(8, 0), LocalTime.of(9, 0))
+        );
+    }
+
+    @Test
+    void 자신의_알림_스케쥴에_대한_정보만_가져올_수있다() {
+        // given
+        AlarmSchedule alarmSchedule = AlarmScheduleCreator.createAlarmSchedule(memberId, AlarmType.WAKE_UP, "알림 스케쥴");
+        alarmSchedule.addAlarms(Collections.emptyList());
+        alarmScheduleScheduleRepository.save(alarmSchedule);
+
+        RetrieveAlarmScheduleRequest request = RetrieveAlarmScheduleRequest.of(alarmSchedule.getId());
+
+        // when & then
+        assertThatThrownBy(() -> {
+            alarmService.retrieveAlarmSchedule(request, 999L);
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private void assertAlarmSchedule(AlarmSchedule alarmSchedule, String description, AlarmType type) {
+        assertAll(
+            () -> assertThat(alarmSchedule.getDescription()).isEqualTo(description),
+            () -> assertThat(alarmSchedule.getType()).isEqualTo(type)
+        );
+    }
+
+    private void assertAlarm(Alarm alarm, DayOfTheWeek dayOfTheWeek, LocalTime reminderTime) {
+        assertAll(
+            () -> assertThat(alarm.getDayOfTheWeek()).isEqualTo(dayOfTheWeek),
+            () -> assertThat(alarm.getReminderTime()).isEqualTo(reminderTime)
+        );
+    }
+
+    private void assertAlarmScheduleInfoResponse(AlarmScheduleInfoResponse response, Long alarmScheduleId, AlarmType type, String description) {
+        assertThat(response.getId()).isEqualTo(alarmScheduleId);
+        assertThat(response.getType()).isEqualTo(type);
+        assertThat(response.getDescription()).isEqualTo(description);
+    }
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/Alarm.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/Alarm.java
@@ -1,0 +1,56 @@
+package com.depromeet.domain.alarm;
+
+import com.depromeet.domain.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Alarm extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "alarm_schedule_id")
+    private AlarmSchedule alarmSchedule;
+
+    @Enumerated(EnumType.STRING)
+    private DayOfTheWeek dayOfTheWeek;
+
+    private LocalTime reminderTime;
+
+    @Builder
+    public Alarm(AlarmSchedule alarmSchedule, DayOfTheWeek dayOfTheWeek, LocalTime reminderTime) {
+        this.alarmSchedule = alarmSchedule;
+        this.dayOfTheWeek = dayOfTheWeek;
+        this.reminderTime = reminderTime;
+    }
+
+    public static Alarm newInstance(DayOfTheWeek dayOfTheWeek, LocalTime reminderTime) {
+        return Alarm.builder()
+            .dayOfTheWeek(dayOfTheWeek)
+            .reminderTime(reminderTime)
+            .build();
+    }
+
+    void setAlarmSchedule(AlarmSchedule alarmSchedule) {
+        this.alarmSchedule = alarmSchedule;
+    }
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/Alarm.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/Alarm.java
@@ -16,6 +16,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import java.time.LocalTime;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -51,6 +52,20 @@ public class Alarm extends BaseTimeEntity {
 
     void setAlarmSchedule(AlarmSchedule alarmSchedule) {
         this.alarmSchedule = alarmSchedule;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Alarm alarm = (Alarm) o;
+        return getDayOfTheWeek() == alarm.getDayOfTheWeek() &&
+            Objects.equals(getReminderTime(), alarm.getReminderTime());
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
     }
 
 }

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/Alarm.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/Alarm.java
@@ -1,6 +1,7 @@
 package com.depromeet.domain.alarm;
 
 import com.depromeet.domain.BaseTimeEntity;
+import com.depromeet.domain.common.DayOfTheWeek;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +17,9 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -48,6 +51,12 @@ public class Alarm extends BaseTimeEntity {
             .dayOfTheWeek(dayOfTheWeek)
             .reminderTime(reminderTime)
             .build();
+    }
+
+    static List<Alarm> defaultWakeUpAlarm(LocalTime wakeUpTime) {
+        return DayOfTheWeek.everyDay.stream()
+            .map(dayOfTheWeek -> Alarm.newInstance(dayOfTheWeek, wakeUpTime))
+            .collect(Collectors.toList());
     }
 
     void setAlarmSchedule(AlarmSchedule alarmSchedule) {

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmCreator.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmCreator.java
@@ -1,5 +1,6 @@
 package com.depromeet.domain.alarm;
 
+import com.depromeet.domain.common.DayOfTheWeek;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmCreator.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmCreator.java
@@ -1,0 +1,18 @@
+package com.depromeet.domain.alarm;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AlarmCreator {
+
+    public static Alarm createAlarm(DayOfTheWeek dayOfTheWeek, LocalTime reminderTime) {
+        return Alarm.builder()
+            .dayOfTheWeek(dayOfTheWeek)
+            .reminderTime(reminderTime)
+            .build();
+    }
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmRepository.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmRepository.java
@@ -1,0 +1,10 @@
+package com.depromeet.domain.alarm;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 테스트용의 Repository
+ */
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmSchedule.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmSchedule.java
@@ -62,7 +62,13 @@ public class AlarmSchedule extends BaseTimeEntity {
         this.alarms.add(alarm);
     }
 
-    public boolean isOwner(Long memberId) {
+    public void validateMemberHasOwner(Long memberId) {
+        if (!isOwner(memberId)) {
+            throw new IllegalArgumentException(String.format("AlarmSchedule (%s)은 멤버 (%s)의 알림 스케쥴이 아닙니다", id, memberId));
+        }
+    }
+
+    private boolean isOwner(Long memberId) {
         return this.memberId.equals(memberId);
     }
 

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmSchedule.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmSchedule.java
@@ -14,6 +14,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,6 +50,12 @@ public class AlarmSchedule extends BaseTimeEntity {
             .type(type)
             .description(description)
             .build();
+    }
+
+    public static AlarmSchedule defaultWakeUpAlarmSchedule(Long memberId, LocalTime wakeUpTime) {
+        AlarmSchedule alarmSchedule = new AlarmSchedule(memberId, AlarmType.WAKE_UP, "기상 알람");
+        alarmSchedule.addAlarms(Alarm.defaultWakeUpAlarm(wakeUpTime));
+        return alarmSchedule;
     }
 
     public void updateAlarmScheduleInfo(AlarmType type, String description) {

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmSchedule.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmSchedule.java
@@ -1,0 +1,69 @@
+package com.depromeet.domain.alarm;
+
+import com.depromeet.domain.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class AlarmSchedule extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    private AlarmType type;
+
+    private String description;
+
+    @OneToMany(mappedBy = "alarmSchedule", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Alarm> alarms = new ArrayList<>();
+
+    @Builder()
+    public AlarmSchedule(Long memberId, AlarmType type, String description) {
+        this.memberId = memberId;
+        this.type = type;
+        this.description = description;
+    }
+
+    public static AlarmSchedule newInstance(Long memberId, AlarmType type, String description) {
+        return AlarmSchedule.builder()
+            .memberId(memberId)
+            .type(type)
+            .description(description)
+            .build();
+    }
+
+    public void addAlarms(List<Alarm> alarmList) {
+        for (Alarm alarm : alarmList) {
+            addAlarm(alarm);
+        }
+    }
+
+    private void addAlarm(Alarm alarm) {
+        alarm.setAlarmSchedule(this);
+        this.alarms.add(alarm);
+    }
+
+    public boolean isOwner(Long memberId) {
+        return this.memberId.equals(memberId);
+    }
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmSchedule.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmSchedule.java
@@ -76,16 +76,6 @@ public class AlarmSchedule extends BaseTimeEntity {
         this.alarms.clear();
     }
 
-    public void validateMemberHasOwner(Long memberId) {
-        if (!isOwner(memberId)) {
-            throw new IllegalArgumentException(String.format("AlarmSchedule (%s)은 멤버 (%s)의 알림 스케쥴이 아닙니다", id, memberId));
-        }
-    }
-
-    private boolean isOwner(Long memberId) {
-        return this.memberId.equals(memberId);
-    }
-
     public boolean hasSameAlarms(AlarmSchedule other) {
         if (this.alarms.size() != other.alarms.size()) {
             return false;

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmSchedule.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmSchedule.java
@@ -51,6 +51,11 @@ public class AlarmSchedule extends BaseTimeEntity {
             .build();
     }
 
+    public void updateAlarmScheduleInfo(AlarmType type, String description) {
+        this.type = type;
+        this.description = description;
+    }
+
     public void addAlarms(List<Alarm> alarmList) {
         for (Alarm alarm : alarmList) {
             addAlarm(alarm);
@@ -62,6 +67,15 @@ public class AlarmSchedule extends BaseTimeEntity {
         this.alarms.add(alarm);
     }
 
+    public void updateAlarms(List<Alarm> alarms) {
+        removeAlarms();
+        addAlarms(alarms);
+    }
+
+    private void removeAlarms() {
+        this.alarms.clear();
+    }
+
     public void validateMemberHasOwner(Long memberId) {
         if (!isOwner(memberId)) {
             throw new IllegalArgumentException(String.format("AlarmSchedule (%s)은 멤버 (%s)의 알림 스케쥴이 아닙니다", id, memberId));
@@ -70,6 +84,13 @@ public class AlarmSchedule extends BaseTimeEntity {
 
     private boolean isOwner(Long memberId) {
         return this.memberId.equals(memberId);
+    }
+
+    public boolean hasSameAlarms(AlarmSchedule other) {
+        if (this.alarms.size() != other.alarms.size()) {
+            return false;
+        }
+        return this.alarms.containsAll(other.alarms);
     }
 
 }

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmScheduleCreator.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmScheduleCreator.java
@@ -1,0 +1,17 @@
+package com.depromeet.domain.alarm;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AlarmScheduleCreator {
+
+    public static AlarmSchedule createAlarmSchedule(Long memberId, AlarmType type, String description) {
+        return AlarmSchedule.builder()
+            .memberId(memberId)
+            .type(type)
+            .description(description)
+            .build();
+    }
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmScheduleRepository.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmScheduleRepository.java
@@ -3,6 +3,6 @@ package com.depromeet.domain.alarm;
 import com.depromeet.domain.alarm.repository.AlarmScheduleRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AlarmScheduleScheduleRepository extends JpaRepository<AlarmSchedule, Long>, AlarmScheduleRepositoryCustom {
+public interface AlarmScheduleRepository extends JpaRepository<AlarmSchedule, Long>, AlarmScheduleRepositoryCustom {
 
 }

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmScheduleScheduleRepository.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmScheduleScheduleRepository.java
@@ -1,0 +1,8 @@
+package com.depromeet.domain.alarm;
+
+import com.depromeet.domain.alarm.repository.AlarmScheduleRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmScheduleScheduleRepository extends JpaRepository<AlarmSchedule, Long>, AlarmScheduleRepositoryCustom {
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmType.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/AlarmType.java
@@ -1,0 +1,7 @@
+package com.depromeet.domain.alarm;
+
+public enum AlarmType {
+
+    WAKE_UP
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/DayOfTheWeek.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/DayOfTheWeek.java
@@ -1,0 +1,37 @@
+package com.depromeet.domain.alarm;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.DayOfWeek;
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor
+public enum DayOfTheWeek {
+
+    MON(DayOfWeek.MONDAY, false),
+    TUE(DayOfWeek.TUESDAY, false),
+    WED(DayOfWeek.WEDNESDAY, false),
+    THU(DayOfWeek.THURSDAY, false),
+    FRI(DayOfWeek.FRIDAY, false),
+    SAT(DayOfWeek.SATURDAY, true),
+    SUN(DayOfWeek.SUNDAY, true);
+
+    private final DayOfWeek dayOfWeek;
+    private final boolean isWeekend;
+
+    private static final Map<DayOfWeek, DayOfTheWeek> cachingDayOfTheWeek = new HashMap<>();
+
+    static {
+        for (DayOfTheWeek dayOfTheWeek : values()) {
+            cachingDayOfTheWeek.put(dayOfTheWeek.getDayOfWeek(), dayOfTheWeek);
+        }
+    }
+
+    public static DayOfTheWeek of(DayOfWeek dayOfWeek) {
+        return cachingDayOfTheWeek.get(dayOfWeek);
+    }
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/repository/AlarmScheduleRepositoryCustom.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/repository/AlarmScheduleRepositoryCustom.java
@@ -8,6 +8,6 @@ public interface AlarmScheduleRepositoryCustom {
 
     List<AlarmSchedule> findAlarmSchedulesByMemberId(Long memberId);
 
-    AlarmSchedule findAlarmScheduleById(Long id);
+    AlarmSchedule findAlarmScheduleByIdAndMemberId(Long id, Long memberId);
 
 }

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/repository/AlarmScheduleRepositoryCustom.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/repository/AlarmScheduleRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.depromeet.domain.alarm.repository;
+
+import com.depromeet.domain.alarm.AlarmSchedule;
+
+import java.util.List;
+
+public interface AlarmScheduleRepositoryCustom {
+
+    List<AlarmSchedule> findAlarmSchedulesByMemberId(Long memberId);
+
+    AlarmSchedule findAlarmScheduleById(Long id);
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/repository/AlarmScheduleRepositoryCustomImpl.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/repository/AlarmScheduleRepositoryCustomImpl.java
@@ -1,0 +1,35 @@
+package com.depromeet.domain.alarm.repository;
+
+import com.depromeet.domain.alarm.AlarmSchedule;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.depromeet.domain.alarm.QAlarm.alarm;
+import static com.depromeet.domain.alarm.QAlarmSchedule.alarmSchedule;
+
+@RequiredArgsConstructor
+public class AlarmScheduleRepositoryCustomImpl implements AlarmScheduleRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<AlarmSchedule> findAlarmSchedulesByMemberId(Long memberId) {
+        return queryFactory.selectFrom(alarmSchedule).distinct()
+            .leftJoin(alarmSchedule.alarms, alarm).fetchJoin()
+            .where(
+                alarmSchedule.memberId.eq(memberId)
+            ).fetch();
+    }
+
+    @Override
+    public AlarmSchedule findAlarmScheduleById(Long id) {
+        return queryFactory.selectFrom(alarmSchedule).distinct()
+            .leftJoin(alarmSchedule.alarms, alarm).fetchJoin()
+            .where(
+                alarmSchedule.id.eq(id)
+            ).fetchOne();
+    }
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/repository/AlarmScheduleRepositoryCustomImpl.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/repository/AlarmScheduleRepositoryCustomImpl.java
@@ -24,11 +24,12 @@ public class AlarmScheduleRepositoryCustomImpl implements AlarmScheduleRepositor
     }
 
     @Override
-    public AlarmSchedule findAlarmScheduleById(Long id) {
+    public AlarmSchedule findAlarmScheduleByIdAndMemberId(Long id, Long memberId) {
         return queryFactory.selectFrom(alarmSchedule).distinct()
             .leftJoin(alarmSchedule.alarms, alarm).fetchJoin()
             .where(
-                alarmSchedule.id.eq(id)
+                alarmSchedule.id.eq(id),
+                alarmSchedule.memberId.eq(memberId)
             ).fetchOne();
     }
 

--- a/miracle-domain/src/main/java/com/depromeet/domain/common/Category.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/common/Category.java
@@ -5,8 +5,6 @@ package com.depromeet.domain.common;
  */
 public enum Category {
 
-    EXERCISE,
-    MEDITATION,
-    READING
+    EXERCISE, MEDITATION, READING, PROMISE, DIARY, PLAN
 
 }

--- a/miracle-domain/src/main/java/com/depromeet/domain/common/DayOfTheWeek.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/common/DayOfTheWeek.java
@@ -1,11 +1,15 @@
-package com.depromeet.domain.alarm;
+package com.depromeet.domain.common;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.time.DayOfWeek;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Getter
 @RequiredArgsConstructor
@@ -22,9 +26,13 @@ public enum DayOfTheWeek {
     private final DayOfWeek dayOfWeek;
     private final boolean isWeekend;
 
+    public static final List<DayOfTheWeek> everyDay = new ArrayList<>();
     private static final Map<DayOfWeek, DayOfTheWeek> cachingDayOfTheWeek = new HashMap<>();
 
     static {
+        everyDay.addAll(Arrays.stream(values())
+            .collect(Collectors.toList()));
+
         for (DayOfTheWeek dayOfTheWeek : values()) {
             cachingDayOfTheWeek.put(dayOfTheWeek.getDayOfWeek(), dayOfTheWeek);
         }

--- a/miracle-domain/src/test/java/com/depromeet/domain/alarm/AlarmScheduleTest.java
+++ b/miracle-domain/src/test/java/com/depromeet/domain/alarm/AlarmScheduleTest.java
@@ -1,5 +1,6 @@
 package com.depromeet.domain.alarm;
 
+import com.depromeet.domain.common.DayOfTheWeek;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalTime;

--- a/miracle-domain/src/test/java/com/depromeet/domain/alarm/AlarmScheduleTest.java
+++ b/miracle-domain/src/test/java/com/depromeet/domain/alarm/AlarmScheduleTest.java
@@ -1,0 +1,77 @@
+package com.depromeet.domain.alarm;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AlarmScheduleTest {
+
+    @Test
+    void hasSameAlarms_테스트_두_알람이_같은경우() {
+        // given
+        AlarmSchedule alarmSchedule1 = AlarmScheduleCreator.createAlarmSchedule(1L, AlarmType.WAKE_UP, "description1");
+        Alarm alarm1 = AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(8, 0));
+        Alarm alarm2 = AlarmCreator.createAlarm(DayOfTheWeek.TUE, LocalTime.of(9, 0));
+        alarmSchedule1.addAlarms(Arrays.asList(alarm1, alarm2));
+
+        AlarmSchedule alarmSchedule2 = AlarmScheduleCreator.createAlarmSchedule(1L, AlarmType.WAKE_UP, "description2");
+        Alarm alarm3 = AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(8, 0));
+        Alarm alarm4 = AlarmCreator.createAlarm(DayOfTheWeek.TUE, LocalTime.of(9, 0));
+        alarmSchedule2.addAlarms(Arrays.asList(alarm3, alarm4));
+
+        // when & then
+        assertTrue(alarmSchedule1.hasSameAlarms(alarmSchedule2));
+    }
+
+    @Test
+    void hasSameAlarms_테스트_둘다_빈경우() {
+        // given
+        AlarmSchedule alarmSchedule1 = AlarmScheduleCreator.createAlarmSchedule(1L, AlarmType.WAKE_UP, "description1");
+        alarmSchedule1.addAlarms(Collections.emptyList());
+
+        AlarmSchedule alarmSchedule2 = AlarmScheduleCreator.createAlarmSchedule(1L, AlarmType.WAKE_UP, "description2");
+        alarmSchedule2.addAlarms(Collections.emptyList());
+
+        // when & then
+        assertTrue(alarmSchedule1.hasSameAlarms(alarmSchedule2));
+    }
+
+    @Test
+    void hasSameAlarms_테스트_알람의_수가_다른경우() {
+        // given
+        AlarmSchedule alarmSchedule1 = AlarmScheduleCreator.createAlarmSchedule(1L, AlarmType.WAKE_UP, "description1");
+        Alarm alarm1 = AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(8, 0));
+        Alarm alarm2 = AlarmCreator.createAlarm(DayOfTheWeek.TUE, LocalTime.of(9, 0));
+        alarmSchedule1.addAlarms(Arrays.asList(alarm1, alarm2));
+
+        AlarmSchedule alarmSchedule2 = AlarmScheduleCreator.createAlarmSchedule(1L, AlarmType.WAKE_UP, "description2");
+        Alarm alarm3 = AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(8, 0));
+        alarmSchedule2.addAlarms(Collections.singletonList(alarm3));
+
+        // when & then
+        assertFalse(alarmSchedule1.hasSameAlarms(alarmSchedule2));
+    }
+
+    @Test
+    void hasSameAlarms_테스트_알람의_수는_같은데_시간이_다른경우() {
+        // given
+        AlarmSchedule alarmSchedule1 = AlarmScheduleCreator.createAlarmSchedule(1L, AlarmType.WAKE_UP, "description1");
+        Alarm alarm1 = AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(8, 0));
+        Alarm alarm2 = AlarmCreator.createAlarm(DayOfTheWeek.TUE, LocalTime.of(9, 0));
+        alarmSchedule1.addAlarms(Arrays.asList(alarm1, alarm2));
+
+        AlarmSchedule alarmSchedule2 = AlarmScheduleCreator.createAlarmSchedule(1L, AlarmType.WAKE_UP, "description2");
+        Alarm alarm3 = AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(8, 0));
+        Alarm alarm4 = AlarmCreator.createAlarm(DayOfTheWeek.TUE, LocalTime.of(10, 0));
+        alarmSchedule2.addAlarms(Arrays.asList(alarm3, alarm4));
+
+        // when & then
+        assertFalse(alarmSchedule1.hasSameAlarms(alarmSchedule2));
+    }
+
+}

--- a/miracle-domain/src/test/java/com/depromeet/domain/alarm/AlarmTest.java
+++ b/miracle-domain/src/test/java/com/depromeet/domain/alarm/AlarmTest.java
@@ -1,5 +1,6 @@
 package com.depromeet.domain.alarm;
 
+import com.depromeet.domain.common.DayOfTheWeek;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalTime;

--- a/miracle-domain/src/test/java/com/depromeet/domain/alarm/AlarmTest.java
+++ b/miracle-domain/src/test/java/com/depromeet/domain/alarm/AlarmTest.java
@@ -1,0 +1,42 @@
+package com.depromeet.domain.alarm;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class AlarmTest {
+
+    @Test
+    void 동등성_테스트_같은_요일_같은_시간인_경우() {
+        // given
+        Alarm alarm1 = AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(8, 0));
+        Alarm alarm2 = AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(8, 0));
+
+        // when & then
+        assertEquals(alarm1, alarm2);
+    }
+
+    @Test
+    void 동등성_테스트_다른_요일_같은_시간인_경우() {
+        // given
+        Alarm alarm1 = AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(8, 0));
+        Alarm alarm2 = AlarmCreator.createAlarm(DayOfTheWeek.TUE, LocalTime.of(8, 0));
+
+        // when & then
+        assertNotEquals(alarm1, alarm2);
+    }
+
+    @Test
+    void 동등성_테스트_같은_요일_다른_시간인경우() {
+        // given
+        Alarm alarm1 = AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(8, 0));
+        Alarm alarm2 = AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(9, 0));
+
+        // when & then
+        assertNotEquals(alarm1, alarm2);
+    }
+
+}


### PR DESCRIPTION
**알람 도메인 & 구현**

- 기상시간(WakeUp)으로 주지 않고 큰 범위에서 알람(Alarm)으로 설정하였으며, 나중에 확장할 수 있도록 생각하였음.
- (type = WAKE_UP)일시 기상 알람을 의미함.
- AlarmSchedule 1개에 n개의 Alarm 이 속할 수 있습니다.

- 현재 09:00로 지정하면 모든 요일 09:00에 알림을 주도록 회의가 진행되었는데,
서버측에서는 확장을 위해 커스텀이 가능하도록 구현함 (사실 그냥 해보고 싶어서이긴합니다...ㅎㅎ)

- AlarmSchedule 을 따로 구현한 이유도 확장.. (Schedule에 대한 노티가 알림 도메인에 추가되면 대응 안될꺼라 생각)

**요구사항 정리 (#15 기상시간 정리)**
- 유저의 기상시간을 받아서 서버에 저장합니다.
- 모든 요일에 시간을 통일하기로 결정되었습니다
- 이 기상시간을 토대로 알림기능을 보내줍니다
- 기상시간을 변경할 수 있습니다.

2020-08-10 변경사항
- 회원가입시, 최초 기상 알림 시간을 설정하도록 변경 (제플린 참고)
- 회원가입시, LocalTime(07:00) 을 입력받고, 모든 요일에 입력받은 시간으로 통일되도록 적용