### PR TITLE
miracle-domain 에서만 compileQuerydsl 과정을 수행하도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,20 +6,16 @@ def javaProjects = [
 buildscript {
     ext {
         springBootVersion = '2.2.8.RELEASE'
-        querydslPluginVersion = '1.0.10'
         kotlinVersion = '1.3.72'
     }
     repositories {
         mavenCentral()
-        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
-        classpath("gradle.plugin.com.ewerk.gradle.plugins:querydsl-plugin:${querydslPluginVersion}")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")
         classpath("org.jetbrains.kotlin:kotlin-allopen:${kotlinVersion}")
         classpath("org.jetbrains.kotlin:kotlin-noarg:${kotlinVersion}")
-        classpath "io.franzbecker:gradle-lombok:4.0.0"
     }
 }
 
@@ -29,10 +25,8 @@ configure(javaProjects) {
     apply plugin: 'eclipse'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
-    apply plugin: "com.ewerk.gradle.plugins.querydsl"
     apply plugin: 'kotlin'
     apply plugin: 'kotlin-spring'
-    apply plugin: "io.franzbecker.gradle-lombok"
 
     group = 'com.depromeet'
     sourceCompatibility = '11'
@@ -60,9 +54,6 @@ configure(javaProjects) {
             exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
         }
 
-        implementation("com.querydsl:querydsl-jpa")
-        implementation("com.querydsl:querydsl-apt")
-
         implementation 'org.springframework.boot:spring-boot-starter-security'
         testImplementation 'org.springframework.security:spring-security-test'
 
@@ -73,52 +64,7 @@ configure(javaProjects) {
         // 자바 + 코틀린 사용시, lombok, querydsl 이슈 확인 필요.
     }
 
-    configurations {
-        compileOnly {
-            extendsFrom annotationProcessor
-        }
-    }
-
     test {
         useJUnitPlatform()
-    }
-
-    def queryDslSrcDir = 'src/main/java/generated'
-
-    querydsl {
-        library = "com.querydsl:querydsl-apt"
-        jpa = true
-        querydslSourcesDir = queryDslSrcDir
-    }
-
-    compileQuerydsl {
-        options.annotationProcessorPath = configurations.querydsl
-    }
-
-    configurations {
-        compileOnly {
-            extendsFrom annotationProcessor
-        }
-        querydsl.extendsFrom compileClasspath
-    }
-
-    sourceSets {
-        main {
-            java {
-                srcDirs = ['src/main/java', queryDslSrcDir]
-            }
-        }
-    }
-
-    project.afterEvaluate {
-        project.tasks.compileQuerydsl.options.compilerArgs = [
-            "-proc:only",
-            "-processor", project.querydsl.processors() +
-                ',lombok.launch.AnnotationProcessorHider$AnnotationProcessor'
-        ]
-    }
-
-    clean {
-        file(queryDslSrcDir).deleteDir()
     }
 }

--- a/miracle-domain/build.gradle
+++ b/miracle-domain/build.gradle
@@ -1,8 +1,72 @@
+buildscript {
+    ext {
+        querydslPluginVersion = '1.0.10'
+    }
+    repositories {
+        mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
+    }
+    dependencies {
+        classpath("gradle.plugin.com.ewerk.gradle.plugins:querydsl-plugin:${querydslPluginVersion}")
+        classpath "io.franzbecker:gradle-lombok:4.0.0"
+    }
+}
+
+apply plugin: "com.ewerk.gradle.plugins.querydsl"
+apply plugin: "io.franzbecker.gradle-lombok"
+
 bootJar { enabled = false }
 jar { enabled = true }
-
 
 dependencies {
     api group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '2.2.8.RELEASE'
     runtimeOnly 'com.h2database:h2'
+
+    implementation("com.querydsl:querydsl-jpa")
+    implementation("com.querydsl:querydsl-apt")
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+def queryDslSrcDir = 'src/main/java/generated'
+
+querydsl {
+    library = "com.querydsl:querydsl-apt"
+    jpa = true
+    querydslSourcesDir = queryDslSrcDir
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src/main/java', queryDslSrcDir]
+        }
+    }
+}
+
+project.afterEvaluate {
+    project.tasks.compileQuerydsl.options.compilerArgs = [
+        "-proc:only",
+        "-processor", project.querydsl.processors() +
+            ',lombok.launch.AnnotationProcessorHider$AnnotationProcessor'
+    ]
+}
+
+clean {
+    file(queryDslSrcDir).deleteDir()
 }


### PR DESCRIPTION
miracle-api:complieQuerydsl 빌드과정 중,
lombok 을 사용하지 않는 ScheduleController 빌드 시에 ApiResponse, MemberSession 클래스를 찾지 못하는 문제가 지속적으로 발생

miracle-api 빌드에는 Querydsl 빌드 과정이 필요하지 않으므로 domain 영역에서만 수행되도록 수정했습니다.