### PR TITLE
스케쥴 도메인 - 수정 API

### DIFF
--- a/http/schedule.http
+++ b/http/schedule.http
@@ -10,10 +10,27 @@ Content-Type: application/json
     "description": "운동하기",
     "loopType": "NONE"
 }
+> {%
+client.global.set("SCHEDULE_ID", response.body["data"]["scheduleId"]);
+ %}
+
 ###
 
 GET {{host}}/api/v1/schedule?year=2020&month=8&day=9
 Authorization: Bearer {{AUTHORIZATION}}
 Content-Type: application/json
 
+###
+
+PUT {{host}}/api/v1/schedule/{{SCHEDULE_ID}}
+Authorization: Bearer {{AUTHORIZATION}}
+Content-Type: application/json
+
+{
+  "startTime": "2020-08-09T16:30:00",
+  "endTime": "2020-08-09T17:00:00",
+  "category": "명상",
+  "description": "명상하기",
+  "loopType": "DAY"
+}
 ###

--- a/http/schedule.http
+++ b/http/schedule.http
@@ -12,7 +12,7 @@ Content-Type: application/json
 }
 ###
 
-GET {{host}}/api/v1/schedule
+GET {{host}}/api/v1/schedule?year=2020&month=8&day=9
 Authorization: Bearer {{AUTHORIZATION}}
 Content-Type: application/json
 

--- a/miracle-api/src/main/java/com/depromeet/controller/schedule/ScheduleController.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/schedule/ScheduleController.java
@@ -3,10 +3,10 @@ package com.depromeet.controller.schedule;
 import com.depromeet.ApiResponse;
 import com.depromeet.config.resolver.LoginMember;
 import com.depromeet.config.session.MemberSession;
-import com.depromeet.service.schedule.CreateScheduleRequest;
-import com.depromeet.service.schedule.CreateScheduleResponse;
-import com.depromeet.service.schedule.GetScheduleResponse;
 import com.depromeet.service.schedule.ScheduleService;
+import com.depromeet.service.schedule.dto.CreateScheduleRequest;
+import com.depromeet.service.schedule.dto.CreateScheduleResponse;
+import com.depromeet.service.schedule.dto.GetScheduleResponse;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,26 +24,26 @@ public class ScheduleController {
     /**
      * 스케쥴을 등록한다.
      *
-     * @param member  가입 멤버 정보
+     * @param session 가입 멤버 정보
      * @param request 등록하고자 하는 스케쥴 정보
      * @return 스케쥴 ID
      */
     @PostMapping(value = "/api/v1/schedule", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ApiResponse<CreateScheduleResponse> createSchedule(@LoginMember MemberSession member, @RequestBody CreateScheduleRequest request) {
-        return ApiResponse.of(scheduleService.createSchedule(member.getMemberId(), request));
+    public ApiResponse<CreateScheduleResponse> createSchedule(@LoginMember MemberSession session, @RequestBody CreateScheduleRequest request) {
+        return ApiResponse.of(scheduleService.createSchedule(session.getMemberId(), request));
     }
 
     /**
      * 특정 날짜의 전체 스케쥴을 조회한다.
      *
-     * @param member 가입 멤버 정보
-     * @param year   조회 년도
-     * @param month  조회 월
-     * @param day    조회 날짜
+     * @param session 가입 멤버 정보
+     * @param year    조회 년도
+     * @param month   조회 월
+     * @param day     조회 날짜
      * @return 해당 날짜에 등록된 전체 스케쥴 정보
      */
     @GetMapping(value = "/api/v1/schedule", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ApiResponse<List<GetScheduleResponse>> getSchedule(@LoginMember MemberSession member, @RequestParam int year, @RequestParam int month, @RequestParam int day) {
-        return ApiResponse.of(scheduleService.getDailySchedule(member.getMemberId(), LocalDate.of(year, month, day)));
+    public ApiResponse<List<GetScheduleResponse>> getSchedule(@LoginMember MemberSession session, @RequestParam int year, @RequestParam int month, @RequestParam int day) {
+        return ApiResponse.of(scheduleService.getDailySchedule(session.getMemberId(), LocalDate.of(year, month, day)));
     }
 }

--- a/miracle-api/src/main/java/com/depromeet/controller/schedule/ScheduleController.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/schedule/ScheduleController.java
@@ -41,8 +41,8 @@ public class ScheduleController {
      * @return 해당 날짜에 등록된 전체 스케쥴 정보
      */
     @GetMapping(value = "/api/v1/schedule", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ApiResponse<List<GetScheduleResponse>> getSchedule(@LoginMember MemberSession session, @RequestParam int year, @RequestParam int month, @RequestParam int day) {
-        return ApiResponse.of(scheduleService.getDailySchedule(session.getMemberId(), LocalDate.of(year, month, day)));
+    public ApiResponse<List<GetScheduleResponse>> retrieveSchedule(@LoginMember MemberSession session, @RequestParam int year, @RequestParam int month, @RequestParam int day) {
+        return ApiResponse.of(scheduleService.retrieveDailySchedule(session.getMemberId(), LocalDate.of(year, month, day)));
     }
 
     /**

--- a/miracle-api/src/main/java/com/depromeet/controller/schedule/ScheduleController.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/schedule/ScheduleController.java
@@ -4,9 +4,7 @@ import com.depromeet.ApiResponse;
 import com.depromeet.config.resolver.LoginMember;
 import com.depromeet.config.session.MemberSession;
 import com.depromeet.service.schedule.ScheduleService;
-import com.depromeet.service.schedule.dto.CreateScheduleRequest;
-import com.depromeet.service.schedule.dto.CreateScheduleResponse;
-import com.depromeet.service.schedule.dto.GetScheduleResponse;
+import com.depromeet.service.schedule.dto.*;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
@@ -45,5 +43,18 @@ public class ScheduleController {
     @GetMapping(value = "/api/v1/schedule", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<List<GetScheduleResponse>> getSchedule(@LoginMember MemberSession session, @RequestParam int year, @RequestParam int month, @RequestParam int day) {
         return ApiResponse.of(scheduleService.getDailySchedule(session.getMemberId(), LocalDate.of(year, month, day)));
+    }
+
+
+    /**
+     * 스케쥴을 수정한다.
+     *
+     * @param request 수정하고자 하는 스케쥴 정보
+     * @param session 가입 멤버 정보
+     * @return 스케쥴 ID
+     */
+    @PutMapping(value = "/api/v1/schedule/{id}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<UpdateScheduleResponse> updateSchedule(@LoginMember MemberSession session, @PathVariable long id, @RequestBody UpdateScheduleRequest request) {
+        return ApiResponse.of(scheduleService.updateSchedule(session.getMemberId(), id, request));
     }
 }

--- a/miracle-api/src/main/java/com/depromeet/controller/schedule/ScheduleController.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/schedule/ScheduleController.java
@@ -45,7 +45,6 @@ public class ScheduleController {
         return ApiResponse.of(scheduleService.getDailySchedule(session.getMemberId(), LocalDate.of(year, month, day)));
     }
 
-
     /**
      * 스케쥴을 수정한다.
      *

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
@@ -62,8 +62,7 @@ public class ScheduleService {
      */
     @Transactional
     public UpdateScheduleResponse updateSchedule(Long memberId, long scheduleId, UpdateScheduleRequest request) {
-        Optional<Schedule> opt = repository.findById(scheduleId);
-        Schedule schedule = opt.orElseThrow(() -> new NoSuchElementException(String.format("스케쥴 (%d)은 존재하지 않습니다", scheduleId)));
+        Schedule schedule = repository.findById(scheduleId).orElseThrow(() -> new NoSuchElementException(String.format("스케쥴 (%d)은 존재하지 않습니다", scheduleId)));
         schedule.update(memberId, request.getStartTime(), request.getEndTime(), request.getCategory(), request.getDescription(), LoopType.of(request.getLoopType()));
         return UpdateScheduleResponse.of(schedule);
     }

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
@@ -42,11 +42,11 @@ public class ScheduleService {
      * @return 해당 날짜에 등록된 전체 스케쥴 정보
      */
     @Transactional(readOnly = true)
-    public List<GetScheduleResponse> getDailySchedule(long memberId, LocalDate date) {
-        List<Schedule> schedules = repository.getSchedulesByMemberIdAndLoopTypeAndYearAndMonthAndDay(memberId, LoopType.NONE, date.getYear(), date.getMonthValue(), date.getDayOfMonth());
-        schedules.addAll(repository.getSchedulesByMemberIdAndLoopType(memberId, LoopType.DAY));
-        schedules.addAll(repository.getSchedulesByMemberIdAndLoopTypeAndDayOfWeek(memberId, LoopType.WEEK, date.getDayOfWeek()));
-        schedules.addAll(repository.getSchedulesByMemberIdAndLoopTypeAndDay(memberId, LoopType.MONTH, date.getDayOfMonth()));
+    public List<GetScheduleResponse> retrieveDailySchedule(long memberId, LocalDate date) {
+        List<Schedule> schedules = repository.findSchedulesByMemberIdAndLoopTypeAndYearAndMonthAndDay(memberId, LoopType.NONE, date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+        schedules.addAll(repository.findSchedulesByMemberIdAndLoopType(memberId, LoopType.DAY));
+        schedules.addAll(repository.findSchedulesByMemberIdAndLoopTypeAndDayOfWeek(memberId, LoopType.WEEK, date.getDayOfWeek()));
+        schedules.addAll(repository.findSchedulesByMemberIdAndLoopTypeAndDay(memberId, LoopType.MONTH, date.getDayOfMonth()));
         return schedules
             .stream()
             .map(GetScheduleResponse::of)

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
@@ -3,11 +3,14 @@ package com.depromeet.service.schedule;
 import com.depromeet.domain.schedule.LoopType;
 import com.depromeet.domain.schedule.Schedule;
 import com.depromeet.domain.schedule.ScheduleRepository;
+import com.depromeet.service.schedule.dto.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -49,5 +52,20 @@ public class ScheduleService {
             .stream()
             .map(GetScheduleResponse::of)
             .collect(Collectors.toList());
+    }
+
+    /**
+     * 데이터 베이스의 스케쥴을 수정한다.
+     *
+     * @param memberId 가입 멤버 ID
+     * @param request  수정하고자 하는 스케쥴 정보
+     * @return 스케쥴 ID
+     */
+    @Transactional
+    public UpdateScheduleResponse updateSchedule(Long memberId, long scheduleId, UpdateScheduleRequest request) {
+        Optional<Schedule> opt = repository.findById(scheduleId);
+        Schedule schedule = opt.orElseThrow(() -> new NoSuchElementException(String.format("스케쥴 (%d)은 존재하지 않습니다", scheduleId)));
+        schedule.update(memberId, request.getStartTime(), request.getEndTime(), request.getCategory(), request.getDescription(), LoopType.of(request.getLoopType()));
+        return UpdateScheduleResponse.of(schedule);
     }
 }

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
@@ -10,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -63,7 +62,7 @@ public class ScheduleService {
     @Transactional
     public UpdateScheduleResponse updateSchedule(Long memberId, long scheduleId, UpdateScheduleRequest request) {
         Schedule schedule = repository.findById(scheduleId).orElseThrow(() -> new NoSuchElementException(String.format("스케쥴 (%d)은 존재하지 않습니다", scheduleId)));
-        schedule.update(memberId, request.getStartTime(), request.getEndTime(), request.getCategory(), request.getDescription(), LoopType.of(request.getLoopType()));
+        schedule.update(memberId, request.getStartTime(), request.getEndTime(), request.getCategory(), request.getDescription(), request.getLoopType());
         return UpdateScheduleResponse.of(schedule);
     }
 }

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 
 @Service
 public class ScheduleService {
-
     private final ScheduleRepository repository;
 
     public ScheduleService(ScheduleRepository repository) {

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/CreateScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/CreateScheduleRequest.java
@@ -1,4 +1,4 @@
-package com.depromeet.service.schedule;
+package com.depromeet.service.schedule.dto;
 
 import com.depromeet.domain.schedule.Schedule;
 import com.fasterxml.jackson.annotation.JsonFormat;

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/CreateScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/CreateScheduleRequest.java
@@ -1,13 +1,17 @@
 package com.depromeet.service.schedule.dto;
 
+import com.depromeet.domain.schedule.LoopType;
 import com.depromeet.domain.schedule.Schedule;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+@ApiModel
 public class CreateScheduleRequest {
 
     @NotBlank(message = "시작시간을 선택해주세요")
@@ -25,14 +29,15 @@ public class CreateScheduleRequest {
     @Length(max = 11, message = "11자 이하로 입력해주세요")
     private String description;
 
+    @ApiModelProperty
     @NotBlank(message = "반복설정을 선택해주세요")
-    private String loopType;
+    private LoopType loopType;
 
     public CreateScheduleRequest() {
         // needed by jackson
     }
 
-    public CreateScheduleRequest(LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
+    public CreateScheduleRequest(LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
         this.startTime = startTime;
         this.endTime = endTime;
         this.category = category;
@@ -60,7 +65,7 @@ public class CreateScheduleRequest {
         return description;
     }
 
-    public String getLoopType() {
+    public LoopType getLoopType() {
         return loopType;
     }
 

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/CreateScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/CreateScheduleRequest.java
@@ -2,17 +2,35 @@ package com.depromeet.service.schedule.dto;
 
 import com.depromeet.domain.schedule.Schedule;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import org.hibernate.validator.constraints.Length;
 
+import javax.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 public class CreateScheduleRequest {
+
+    @NotBlank(message = "시작시간을 선택해주세요")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime startTime;
+
+    @NotBlank(message = "종료시간을 선택해주세요")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime endTime;
+
+    @NotBlank(message = "카테고리를 선택해주세요")
     private String category;
+
+    @NotBlank(message = "설명을 입력해주세요")
+    @Length(max = 11, message = "11자 이하로 입력해주세요")
     private String description;
+
+    @NotBlank(message = "반복설정을 선택해주세요")
     private String loopType;
+
+    public CreateScheduleRequest() {
+        // needed by jackson
+    }
 
     public CreateScheduleRequest(LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
         this.startTime = startTime;
@@ -24,5 +42,42 @@ public class CreateScheduleRequest {
 
     public Schedule toEntity(long memberId) {
         return Schedule.of(memberId, startTime, endTime, category, description, loopType);
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getLoopType() {
+        return loopType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CreateScheduleRequest request = (CreateScheduleRequest) o;
+        return Objects.equals(startTime, request.startTime) &&
+            Objects.equals(endTime, request.endTime) &&
+            Objects.equals(category, request.category) &&
+            Objects.equals(description, request.description) &&
+            Objects.equals(loopType, request.loopType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(startTime, endTime, category, description, loopType);
     }
 }

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/CreateScheduleResponse.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/CreateScheduleResponse.java
@@ -1,4 +1,4 @@
-package com.depromeet.service.schedule;
+package com.depromeet.service.schedule.dto;
 
 import com.depromeet.domain.schedule.Schedule;
 

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/GetScheduleResponse.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/GetScheduleResponse.java
@@ -1,4 +1,4 @@
-package com.depromeet.service.schedule;
+package com.depromeet.service.schedule.dto;
 
 import com.depromeet.domain.schedule.Schedule;
 
@@ -35,5 +35,41 @@ public class GetScheduleResponse {
 
     public long getId() {
         return id;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getMonth() {
+        return month;
+    }
+
+    public int getDay() {
+        return day;
+    }
+
+    public int getDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getLoopType() {
+        return loopType;
     }
 }

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/GetScheduleResponse.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/GetScheduleResponse.java
@@ -1,9 +1,13 @@
 package com.depromeet.service.schedule.dto;
 
+import com.depromeet.domain.schedule.LoopType;
 import com.depromeet.domain.schedule.Schedule;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 import java.time.LocalTime;
 
+@ApiModel
 public class GetScheduleResponse {
     private long id;
     private int year;
@@ -14,9 +18,10 @@ public class GetScheduleResponse {
     private LocalTime endTime;
     private String category;
     private String description;
-    private String loopType;
+    @ApiModelProperty
+    private LoopType loopType;
 
-    public GetScheduleResponse(long id, int year, int month, int day, int dayOfWeek, LocalTime startTime, LocalTime endTime, String category, String description, String loopType) {
+    public GetScheduleResponse(long id, int year, int month, int day, int dayOfWeek, LocalTime startTime, LocalTime endTime, String category, String description, LoopType loopType) {
         this.id = id;
         this.year = year;
         this.month = month;
@@ -30,7 +35,7 @@ public class GetScheduleResponse {
     }
 
     public static GetScheduleResponse of(Schedule schedule) {
-        return new GetScheduleResponse(schedule.getId(), schedule.getYear(), schedule.getMonth(), schedule.getDay(), schedule.getDayOfWeek().getValue(), schedule.getStartTime(), schedule.getEndTime(), schedule.getCategory(), schedule.getDescription(), schedule.getLoopType().getText());
+        return new GetScheduleResponse(schedule.getId(), schedule.getYear(), schedule.getMonth(), schedule.getDay(), schedule.getDayOfWeek().getValue(), schedule.getStartTime(), schedule.getEndTime(), schedule.getCategory(), schedule.getDescription(), schedule.getLoopType());
     }
 
     public long getId() {
@@ -69,7 +74,7 @@ public class GetScheduleResponse {
         return description;
     }
 
-    public String getLoopType() {
+    public LoopType getLoopType() {
         return loopType;
     }
 }

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/UpdateScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/UpdateScheduleRequest.java
@@ -1,7 +1,9 @@
 package com.depromeet.service.schedule.dto;
 
+import com.depromeet.domain.schedule.LoopType;
 import com.depromeet.domain.schedule.Schedule;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.annotations.ApiModelProperty;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotBlank;
@@ -25,14 +27,15 @@ public class UpdateScheduleRequest {
     @Length(max = 11, message = "11자 이하로 입력해주세요")
     private String description;
 
+    @ApiModelProperty
     @NotBlank(message = "반복설정을 선택해주세요")
-    private String loopType;
+    private LoopType loopType;
 
     public UpdateScheduleRequest() {
         // needed by jackson
     }
 
-    public UpdateScheduleRequest(LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
+    public UpdateScheduleRequest(LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
         this.startTime = startTime;
         this.endTime = endTime;
         this.category = category;
@@ -60,7 +63,7 @@ public class UpdateScheduleRequest {
         return description;
     }
 
-    public String getLoopType() {
+    public LoopType getLoopType() {
         return loopType;
     }
 

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/UpdateScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/UpdateScheduleRequest.java
@@ -1,0 +1,48 @@
+package com.depromeet.service.schedule.dto;
+
+import com.depromeet.domain.schedule.Schedule;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public class UpdateScheduleRequest {
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime startTime;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime endTime;
+    private String category;
+    private String description;
+    private String loopType;
+
+    public UpdateScheduleRequest(LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.category = category;
+        this.description = description;
+        this.loopType = loopType;
+    }
+
+    public Schedule toEntity(long memberId) {
+        return Schedule.of(memberId, startTime, endTime, category, description, loopType);
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getLoopType() {
+        return loopType;
+    }
+}

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/UpdateScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/UpdateScheduleRequest.java
@@ -2,17 +2,35 @@ package com.depromeet.service.schedule.dto;
 
 import com.depromeet.domain.schedule.Schedule;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import org.hibernate.validator.constraints.Length;
 
+import javax.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 public class UpdateScheduleRequest {
+
+    @NotBlank(message = "시작시간을 선택해주세요")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime startTime;
+
+    @NotBlank(message = "종료시간을 선택해주세요")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime endTime;
+
+    @NotBlank(message = "카테고리를 선택해주세요")
     private String category;
+
+    @NotBlank(message = "설명을 입력해주세요")
+    @Length(max = 11, message = "11자 이하로 입력해주세요")
     private String description;
+
+    @NotBlank(message = "반복설정을 선택해주세요")
     private String loopType;
+
+    public UpdateScheduleRequest() {
+        // needed by jackson
+    }
 
     public UpdateScheduleRequest(LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
         this.startTime = startTime;
@@ -44,5 +62,22 @@ public class UpdateScheduleRequest {
 
     public String getLoopType() {
         return loopType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UpdateScheduleRequest request = (UpdateScheduleRequest) o;
+        return Objects.equals(startTime, request.startTime) &&
+            Objects.equals(endTime, request.endTime) &&
+            Objects.equals(category, request.category) &&
+            Objects.equals(description, request.description) &&
+            Objects.equals(loopType, request.loopType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(startTime, endTime, category, description, loopType);
     }
 }

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/UpdateScheduleResponse.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/UpdateScheduleResponse.java
@@ -1,0 +1,19 @@
+package com.depromeet.service.schedule.dto;
+
+import com.depromeet.domain.schedule.Schedule;
+
+public class UpdateScheduleResponse {
+    private long scheduleId;
+
+    private UpdateScheduleResponse(long scheduleId) {
+        this.scheduleId = scheduleId;
+    }
+
+    public static UpdateScheduleResponse of(Schedule schedule) {
+        return new UpdateScheduleResponse(schedule.getId());
+    }
+
+    public long getScheduleId() {
+        return scheduleId;
+    }
+}

--- a/miracle-api/src/main/java/com/depromeet/util/JsonUtils.java
+++ b/miracle-api/src/main/java/com/depromeet/util/JsonUtils.java
@@ -1,0 +1,47 @@
+package com.depromeet.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class JsonUtils {
+    private static final Logger log = LoggerFactory.getLogger(JsonUtils.class);
+
+    private static final ObjectMapper mapper;
+
+    static {
+        mapper = Jackson2ObjectMapperBuilder
+            .json()
+            .featuresToDisable(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS)
+            .modules(new JavaTimeModule())
+            .build();
+    }
+
+    public static String toJson(Object object) {
+        try {
+            return mapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to convert object to JSON string", e);
+            return null;
+        }
+    }
+
+    public static <T> T toObject(String json, Class<T> clazz) {
+        try {
+            return mapper.readValue(json, clazz);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to convert object to JSON string", e);
+        }
+    }
+
+    public static void write(Writer writer, Object value) throws IOException {
+        new ObjectMapper().writeValue(writer, value);
+    }
+}

--- a/miracle-api/src/test/java/com/depromeet/controller/InMemoryLoginMemberArgumentResolver.java
+++ b/miracle-api/src/test/java/com/depromeet/controller/InMemoryLoginMemberArgumentResolver.java
@@ -1,0 +1,29 @@
+package com.depromeet.controller;
+
+import com.depromeet.config.resolver.LoginMember;
+import com.depromeet.config.session.MemberSession;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class InMemoryLoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+    private final long memberId;
+
+    public InMemoryLoginMemberArgumentResolver(long memberId) {
+        this.memberId = memberId;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasAnnotation = parameter.getParameterAnnotation(LoginMember.class) != null;
+        boolean isMatchType = parameter.getParameterType().equals(MemberSession.class);
+        return hasAnnotation && isMatchType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        return new MemberSession(memberId);
+    }
+}

--- a/miracle-api/src/test/java/com/depromeet/controller/schedule/ScheduleControllerTest.java
+++ b/miracle-api/src/test/java/com/depromeet/controller/schedule/ScheduleControllerTest.java
@@ -1,0 +1,147 @@
+package com.depromeet.controller.schedule;
+
+import com.depromeet.controller.InMemoryLoginMemberArgumentResolver;
+import com.depromeet.domain.schedule.Schedule;
+import com.depromeet.service.schedule.ScheduleService;
+import com.depromeet.service.schedule.dto.*;
+import com.depromeet.util.JsonUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ScheduleController 테스트")
+class ScheduleControllerTest {
+
+    private final long memberId = 1L;
+    private final LocalDateTime startDateTime = LocalDateTime.of(2020, 8, 12, 8, 0, 0);
+    private final LocalDateTime endDateTime = LocalDateTime.of(2020, 8, 12, 9, 0, 0);
+    private final LocalTime startTime = LocalTime.of(8, 0);
+    private final LocalTime endTime = LocalTime.of(9, 0);
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private ScheduleService service;
+
+    @InjectMocks
+    private ScheduleController controller;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+            .standaloneSetup(controller)
+            .addFilter(new CharacterEncodingFilter("UTF-8"))
+            .setCustomArgumentResolvers(new InMemoryLoginMemberArgumentResolver(memberId))
+            .build();
+    }
+
+    @DisplayName("스케쥴을 등록할 수 있다")
+    @Test
+    void createSchedule_ShouldSuccess() throws Exception {
+        CreateScheduleRequest request = new CreateScheduleRequest(startDateTime, endDateTime, "category", "description", "NONE");
+        Schedule schedule = request.toEntity(memberId);
+
+        Class clazz = Class.forName("com.depromeet.domain.schedule.Schedule");
+        Field field = clazz.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(schedule, memberId);
+
+        // given
+        given(service.createSchedule(memberId, request)).willReturn(CreateScheduleResponse.of(schedule));
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(post("/api/v1/schedule")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(JsonUtils.toJson(request))
+        );
+
+        // then
+        resultActions.andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.data.scheduleId").isNumber())
+            .andExpect(jsonPath("$.data.scheduleId").value(1L));
+    }
+
+    @DisplayName("스케쥴을 조회할 수 있다")
+    @Test
+    void retrieveSchedule_ShouldSuccess() throws Exception {
+        // given
+        given(service.retrieveDailySchedule(memberId, LocalDate.of(2020, 8, 12))).willReturn(Arrays.asList(new GetScheduleResponse(1L, 2020, 8, 12, 4, startTime, endTime, "category", "description", "NONE")));
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(
+            get("/api/v1/schedule")
+                .param("year", "2020")
+                .param("month", "8")
+                .param("day", "12")
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.data.[0].id").value(1L))
+            .andExpect(jsonPath("$.data.[0].year").value(2020))
+            .andExpect(jsonPath("$.data.[0].month").value(8))
+            .andExpect(jsonPath("$.data.[0].day").value(12))
+            .andExpect(jsonPath("$.data.[0].dayOfWeek").value(4))
+            .andExpect(jsonPath("$.data.[0].startTime").exists())
+            .andExpect(jsonPath("$.data.[0].endTime").exists())
+            .andExpect(jsonPath("$.data.[0].category").value("category"))
+            .andExpect(jsonPath("$.data.[0].description").value("description"))
+            .andExpect(jsonPath("$.data.[0].loopType").value("NONE"));
+    }
+
+    @DisplayName("스케쥴을 수정할 수 있다")
+    @Test
+    void updateSchedule_ShouldSuccess() throws Exception {
+        UpdateScheduleRequest request = new UpdateScheduleRequest(startDateTime, endDateTime, "category", "description", "NONE");
+        Schedule schedule = request.toEntity(memberId);
+
+        Class clazz = Class.forName("com.depromeet.domain.schedule.Schedule");
+        Field field = clazz.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(schedule, memberId);
+
+        // given
+        given(service.updateSchedule(memberId, 1L, request)).willReturn(UpdateScheduleResponse.of(schedule));
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(put("/api/v1/schedule/1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(JsonUtils.toJson(request))
+        );
+
+        // then
+        resultActions.andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.data.scheduleId").isNumber())
+            .andExpect(jsonPath("$.data.scheduleId").value(1L));
+    }
+}

--- a/miracle-api/src/test/java/com/depromeet/controller/schedule/ScheduleControllerTest.java
+++ b/miracle-api/src/test/java/com/depromeet/controller/schedule/ScheduleControllerTest.java
@@ -1,6 +1,7 @@
 package com.depromeet.controller.schedule;
 
 import com.depromeet.controller.InMemoryLoginMemberArgumentResolver;
+import com.depromeet.domain.schedule.LoopType;
 import com.depromeet.domain.schedule.Schedule;
 import com.depromeet.service.schedule.ScheduleService;
 import com.depromeet.service.schedule.dto.*;
@@ -61,7 +62,7 @@ class ScheduleControllerTest {
     @DisplayName("스케쥴을 등록할 수 있다")
     @Test
     void createSchedule_ShouldSuccess() throws Exception {
-        CreateScheduleRequest request = new CreateScheduleRequest(startDateTime, endDateTime, "category", "description", "NONE");
+        CreateScheduleRequest request = new CreateScheduleRequest(startDateTime, endDateTime, "category", "description", LoopType.NONE);
         Schedule schedule = request.toEntity(memberId);
 
         Class clazz = Class.forName("com.depromeet.domain.schedule.Schedule");
@@ -90,7 +91,7 @@ class ScheduleControllerTest {
     @Test
     void retrieveSchedule_ShouldSuccess() throws Exception {
         // given
-        given(service.retrieveDailySchedule(memberId, LocalDate.of(2020, 8, 12))).willReturn(Arrays.asList(new GetScheduleResponse(1L, 2020, 8, 12, 4, startTime, endTime, "category", "description", "NONE")));
+        given(service.retrieveDailySchedule(memberId, LocalDate.of(2020, 8, 12))).willReturn(Arrays.asList(new GetScheduleResponse(1L, 2020, 8, 12, 4, startTime, endTime, "category", "description", LoopType.NONE)));
 
         // when
         final ResultActions resultActions = mockMvc.perform(
@@ -114,13 +115,13 @@ class ScheduleControllerTest {
             .andExpect(jsonPath("$.data.[0].endTime").exists())
             .andExpect(jsonPath("$.data.[0].category").value("category"))
             .andExpect(jsonPath("$.data.[0].description").value("description"))
-            .andExpect(jsonPath("$.data.[0].loopType").value("NONE"));
+            .andExpect(jsonPath("$.data.[0].loopType").exists());
     }
 
     @DisplayName("스케쥴을 수정할 수 있다")
     @Test
     void updateSchedule_ShouldSuccess() throws Exception {
-        UpdateScheduleRequest request = new UpdateScheduleRequest(startDateTime, endDateTime, "category", "description", "NONE");
+        UpdateScheduleRequest request = new UpdateScheduleRequest(startDateTime, endDateTime, "category", "description", LoopType.NONE);
         Schedule schedule = request.toEntity(memberId);
 
         Class clazz = Class.forName("com.depromeet.domain.schedule.Schedule");

--- a/miracle-api/src/test/java/com/depromeet/service/schedule/InMemoryScheduleRepository.java
+++ b/miracle-api/src/test/java/com/depromeet/service/schedule/InMemoryScheduleRepository.java
@@ -51,7 +51,7 @@ public class InMemoryScheduleRepository implements ScheduleRepository {
     }
 
     @Override
-    public List<Schedule> getSchedulesByMemberIdAndLoopTypeAndYearAndMonthAndDay(long memberId, LoopType loopType, int year, int month, int day) {
+    public List<Schedule> findSchedulesByMemberIdAndLoopTypeAndYearAndMonthAndDay(long memberId, LoopType loopType, int year, int month, int day) {
         return schedules
             .stream()
             .filter(s -> s.getMemberId() == memberId)
@@ -63,7 +63,7 @@ public class InMemoryScheduleRepository implements ScheduleRepository {
     }
 
     @Override
-    public List<Schedule> getSchedulesByMemberIdAndLoopType(long memberId, LoopType loopType) {
+    public List<Schedule> findSchedulesByMemberIdAndLoopType(long memberId, LoopType loopType) {
         return schedules
             .stream()
             .filter(s -> s.getMemberId() == memberId)
@@ -72,7 +72,7 @@ public class InMemoryScheduleRepository implements ScheduleRepository {
     }
 
     @Override
-    public List<Schedule> getSchedulesByMemberIdAndLoopTypeAndDayOfWeek(long memberId, LoopType loopType, DayOfWeek dayOfWeek) {
+    public List<Schedule> findSchedulesByMemberIdAndLoopTypeAndDayOfWeek(long memberId, LoopType loopType, DayOfWeek dayOfWeek) {
         return schedules
             .stream()
             .filter(s -> s.getMemberId() == memberId)
@@ -82,7 +82,7 @@ public class InMemoryScheduleRepository implements ScheduleRepository {
     }
 
     @Override
-    public List<Schedule> getSchedulesByMemberIdAndLoopTypeAndDay(long memberId, LoopType loopType, int day) {
+    public List<Schedule> findSchedulesByMemberIdAndLoopTypeAndDay(long memberId, LoopType loopType, int day) {
         return schedules
             .stream()
             .filter(s -> s.getMemberId() == memberId)

--- a/miracle-api/src/test/java/com/depromeet/service/schedule/InMemoryScheduleRepository.java
+++ b/miracle-api/src/test/java/com/depromeet/service/schedule/InMemoryScheduleRepository.java
@@ -24,19 +24,19 @@ public class InMemoryScheduleRepository implements ScheduleRepository {
     private long currentId = 1L;
 
     public InMemoryScheduleRepository() {
-        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 8, 8, 6, 0), LocalDateTime.of(2020, 8, 8, 6, 30), "기상", "기상하기", LoopType.NONE.getText()));
-        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 8, 8, 6, 0), LocalDateTime.of(2020, 8, 8, 6, 30), "기상", "기상하기", LoopType.DAY.getText()));
-        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 8, 1, 6, 0), LocalDateTime.of(2020, 8, 1, 6, 30), "기상", "기상하기", LoopType.WEEK.getText()));
-        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 9, 8, 6, 0), LocalDateTime.of(2020, 9, 8, 6, 30), "기상", "기상하기", LoopType.MONTH.getText()));
-        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 9, 9, 6, 0), LocalDateTime.of(2020, 9, 9, 6, 30), "취침", "취침하기", LoopType.NONE.getText()));
-        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 7, 10, 20, 0), LocalDateTime.of(2020, 7, 10, 21, 0), "취침", "취침하기", LoopType.NONE.getText()));
-        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 7, 10, 20, 0), LocalDateTime.of(2020, 7, 10, 21, 0), "취침", "취침하기", LoopType.DAY.getText()));
-        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 7, 17, 20, 0), LocalDateTime.of(2020, 7, 17, 21, 0), "취침", "취침하기", LoopType.WEEK.getText()));
-        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 6, 10, 20, 0), LocalDateTime.of(2020, 6, 10, 21, 0), "취침", "취침하기", LoopType.MONTH.getText()));
-        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 9, 10, 20, 0), LocalDateTime.of(2020, 9, 10, 21, 0), "기상", "기상하기", LoopType.WEEK.getText()));
+        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 8, 8, 6, 0), LocalDateTime.of(2020, 8, 8, 6, 30), "기상", "기상하기", LoopType.NONE));
+        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 8, 8, 6, 0), LocalDateTime.of(2020, 8, 8, 6, 30), "기상", "기상하기", LoopType.DAY));
+        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 8, 1, 6, 0), LocalDateTime.of(2020, 8, 1, 6, 30), "기상", "기상하기", LoopType.WEEK));
+        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 9, 8, 6, 0), LocalDateTime.of(2020, 9, 8, 6, 30), "기상", "기상하기", LoopType.MONTH));
+        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 9, 9, 6, 0), LocalDateTime.of(2020, 9, 9, 6, 30), "취침", "취침하기", LoopType.NONE));
+        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 7, 10, 20, 0), LocalDateTime.of(2020, 7, 10, 21, 0), "취침", "취침하기", LoopType.NONE));
+        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 7, 10, 20, 0), LocalDateTime.of(2020, 7, 10, 21, 0), "취침", "취침하기", LoopType.DAY));
+        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 7, 17, 20, 0), LocalDateTime.of(2020, 7, 17, 21, 0), "취침", "취침하기", LoopType.WEEK));
+        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 6, 10, 20, 0), LocalDateTime.of(2020, 6, 10, 21, 0), "취침", "취침하기", LoopType.MONTH));
+        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 9, 10, 20, 0), LocalDateTime.of(2020, 9, 10, 21, 0), "기상", "기상하기", LoopType.WEEK));
     }
 
-    private Schedule generateSchedule(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
+    private Schedule generateSchedule(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
         Schedule schedule = Schedule.of(memberId, startTime, endTime, category, description, loopType);
         try {
         Class clazz = Class.forName("com.depromeet.domain.schedule.Schedule");

--- a/miracle-api/src/test/java/com/depromeet/service/schedule/InMemoryScheduleRepository.java
+++ b/miracle-api/src/test/java/com/depromeet/service/schedule/InMemoryScheduleRepository.java
@@ -1,0 +1,213 @@
+package com.depromeet.service.schedule;
+
+import com.depromeet.domain.schedule.LoopType;
+import com.depromeet.domain.schedule.Schedule;
+import com.depromeet.domain.schedule.ScheduleRepository;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.lang.reflect.Field;
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class InMemoryScheduleRepository implements ScheduleRepository {
+
+    public static final long MEMBER_1 = 1L;
+    public static final long MEMBER_2 = 2L;
+    private final List<Schedule> schedules = new ArrayList<>();
+    private long currentId = 1L;
+
+    public InMemoryScheduleRepository() {
+        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 8, 8, 6, 0), LocalDateTime.of(2020, 8, 8, 6, 30), "기상", "기상하기", LoopType.NONE.getText()));
+        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 8, 8, 6, 0), LocalDateTime.of(2020, 8, 8, 6, 30), "기상", "기상하기", LoopType.DAY.getText()));
+        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 8, 1, 6, 0), LocalDateTime.of(2020, 8, 1, 6, 30), "기상", "기상하기", LoopType.WEEK.getText()));
+        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 9, 8, 6, 0), LocalDateTime.of(2020, 9, 8, 6, 30), "기상", "기상하기", LoopType.MONTH.getText()));
+        schedules.add(generateSchedule(MEMBER_1, LocalDateTime.of(2020, 9, 9, 6, 0), LocalDateTime.of(2020, 9, 9, 6, 30), "취침", "취침하기", LoopType.NONE.getText()));
+        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 7, 10, 20, 0), LocalDateTime.of(2020, 7, 10, 21, 0), "취침", "취침하기", LoopType.NONE.getText()));
+        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 7, 10, 20, 0), LocalDateTime.of(2020, 7, 10, 21, 0), "취침", "취침하기", LoopType.DAY.getText()));
+        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 7, 17, 20, 0), LocalDateTime.of(2020, 7, 17, 21, 0), "취침", "취침하기", LoopType.WEEK.getText()));
+        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 6, 10, 20, 0), LocalDateTime.of(2020, 6, 10, 21, 0), "취침", "취침하기", LoopType.MONTH.getText()));
+        schedules.add(generateSchedule(MEMBER_2, LocalDateTime.of(2020, 9, 10, 20, 0), LocalDateTime.of(2020, 9, 10, 21, 0), "기상", "기상하기", LoopType.WEEK.getText()));
+    }
+
+    private Schedule generateSchedule(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
+        Schedule schedule = Schedule.of(memberId, startTime, endTime, category, description, loopType);
+        try {
+        Class clazz = Class.forName("com.depromeet.domain.schedule.Schedule");
+        Field field = clazz.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(schedule, currentId++);
+        } catch (ReflectiveOperationException e) {
+            e.printStackTrace();
+            return null;
+        }
+        return schedule;
+    }
+
+    @Override
+    public List<Schedule> getSchedulesByMemberIdAndLoopTypeAndYearAndMonthAndDay(long memberId, LoopType loopType, int year, int month, int day) {
+        return schedules
+            .stream()
+            .filter(s -> s.getMemberId() == memberId)
+            .filter(s -> s.getLoopType().equals(loopType))
+            .filter(s -> s.getYear() == year)
+            .filter(s -> s.getMonth() == month)
+            .filter(s -> s.getDay() == day)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Schedule> getSchedulesByMemberIdAndLoopType(long memberId, LoopType loopType) {
+        return schedules
+            .stream()
+            .filter(s -> s.getMemberId() == memberId)
+            .filter(s -> s.getLoopType().equals(loopType))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Schedule> getSchedulesByMemberIdAndLoopTypeAndDayOfWeek(long memberId, LoopType loopType, DayOfWeek dayOfWeek) {
+        return schedules
+            .stream()
+            .filter(s -> s.getMemberId() == memberId)
+            .filter(s -> s.getLoopType().equals(loopType))
+            .filter(s -> s.getDayOfWeek().equals(dayOfWeek))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Schedule> getSchedulesByMemberIdAndLoopTypeAndDay(long memberId, LoopType loopType, int day) {
+        return schedules
+            .stream()
+            .filter(s -> s.getMemberId() == memberId)
+            .filter(s -> s.getLoopType().equals(loopType))
+            .filter(s -> s.getDay() == day)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Schedule> findAll() {
+        return null;
+    }
+
+    @Override
+    public List<Schedule> findAll(Sort sort) {
+        return null;
+    }
+
+    @Override
+    public List<Schedule> findAllById(Iterable<Long> longs) {
+        return null;
+    }
+
+    @Override
+    public <S extends Schedule> List<S> saveAll(Iterable<S> entities) {
+        return null;
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public <S extends Schedule> S saveAndFlush(S entity) {
+        return null;
+    }
+
+    @Override
+    public void deleteInBatch(Iterable<Schedule> entities) {
+
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+
+    }
+
+    @Override
+    public Schedule getOne(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public <S extends Schedule> List<S> findAll(Example<S> example) {
+        return null;
+    }
+
+    @Override
+    public <S extends Schedule> List<S> findAll(Example<S> example, Sort sort) {
+        return null;
+    }
+
+    @Override
+    public Page<Schedule> findAll(Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public <S extends Schedule> S save(S entity) {
+        return null;
+    }
+
+    @Override
+    public Optional<Schedule> findById(Long aLong) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean existsById(Long aLong) {
+        return false;
+    }
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public void deleteById(Long aLong) {
+
+    }
+
+    @Override
+    public void delete(Schedule entity) {
+
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends Schedule> entities) {
+
+    }
+
+    @Override
+    public void deleteAll() {
+
+    }
+
+    @Override
+    public <S extends Schedule> Optional<S> findOne(Example<S> example) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <S extends Schedule> Page<S> findAll(Example<S> example, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public <S extends Schedule> long count(Example<S> example) {
+        return 0;
+    }
+
+    @Override
+    public <S extends Schedule> boolean exists(Example<S> example) {
+        return false;
+    }
+}

--- a/miracle-api/src/test/java/com/depromeet/service/schedule/ScheduleServiceTest.java
+++ b/miracle-api/src/test/java/com/depromeet/service/schedule/ScheduleServiceTest.java
@@ -1,19 +1,12 @@
 package com.depromeet.service.schedule;
 
-import com.depromeet.domain.schedule.LoopType;
-import com.depromeet.domain.schedule.Schedule;
-import com.depromeet.domain.schedule.ScheduleRepository;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import com.depromeet.service.schedule.dto.GetScheduleResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,40 +15,18 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Schedule Service Test")
-@SpringBootTest
 class ScheduleServiceTest {
 
-    public static final long MEMBER_1 = 1L;
-    public static final long MEMBER_2 = 2L;
     private ScheduleService service;
 
-    @Autowired
-    private ScheduleRepository repository;
-
-    @BeforeEach
-    public void setUp() {
-        this.service = new ScheduleService(repository);
-        repository.save(Schedule.of(MEMBER_1, LocalDateTime.of(2020, 8, 8, 6, 0), LocalDateTime.of(2020, 8, 8, 6, 30), "기상", "기상하기", LoopType.NONE.getText()));
-        repository.save(Schedule.of(MEMBER_1, LocalDateTime.of(2020, 8, 8, 6, 0), LocalDateTime.of(2020, 8, 8, 6, 30), "기상", "기상하기", LoopType.DAY.getText()));
-        repository.save(Schedule.of(MEMBER_1, LocalDateTime.of(2020, 8, 1, 6, 0), LocalDateTime.of(2020, 8, 1, 6, 30), "기상", "기상하기", LoopType.WEEK.getText()));
-        repository.save(Schedule.of(MEMBER_1, LocalDateTime.of(2020, 9, 8, 6, 0), LocalDateTime.of(2020, 9, 8, 6, 30), "기상", "기상하기", LoopType.MONTH.getText()));
-        repository.save(Schedule.of(MEMBER_1, LocalDateTime.of(2020, 9, 9, 6, 0), LocalDateTime.of(2020, 9, 9, 6, 30), "취침", "취침하기", LoopType.NONE.getText()));
-        repository.save(Schedule.of(MEMBER_2, LocalDateTime.of(2020, 7, 10, 20, 0), LocalDateTime.of(2020, 7, 10, 21, 0), "취침", "취침하기", LoopType.NONE.getText()));
-        repository.save(Schedule.of(MEMBER_2, LocalDateTime.of(2020, 7, 10, 20, 0), LocalDateTime.of(2020, 7, 10, 21, 0), "취침", "취침하기", LoopType.DAY.getText()));
-        repository.save(Schedule.of(MEMBER_2, LocalDateTime.of(2020, 7, 17, 20, 0), LocalDateTime.of(2020, 7, 17, 21, 0), "취침", "취침하기", LoopType.WEEK.getText()));
-        repository.save(Schedule.of(MEMBER_2, LocalDateTime.of(2020, 6, 10, 20, 0), LocalDateTime.of(2020, 6, 10, 21, 0), "취침", "취침하기", LoopType.MONTH.getText()));
-        repository.save(Schedule.of(MEMBER_2, LocalDateTime.of(2020, 9, 10, 20, 0), LocalDateTime.of(2020, 9, 10, 21, 0), "기상", "기상하기", LoopType.WEEK.getText()));
-    }
-
-    @AfterEach
-    public void clean() {
-        repository.deleteAll();
+    public ScheduleServiceTest() {
+        this.service = new ScheduleService(new InMemoryScheduleRepository());
     }
 
     @DisplayName("하루 동안의 스케쥴을 조회 할 수 있다")
     @ParameterizedTest
     @MethodSource("source_getDailySchedule_ShouldSuccess")
-    public void getDailySchedule_ShouldSuccess(long memberId, LocalDate date, List<Long> scheduleIds) {
+    void getDailySchedule_ShouldSuccess(long memberId, LocalDate date, List<Long> scheduleIds) {
         List<GetScheduleResponse> response = service.getDailySchedule(memberId, date);
 
         List<Long> result = response
@@ -67,10 +38,10 @@ class ScheduleServiceTest {
         assertThat(scheduleIds.equals(result)).isTrue();
     }
 
-    public static Stream<Arguments> source_getDailySchedule_ShouldSuccess() {
+    static Stream<Arguments> source_getDailySchedule_ShouldSuccess() {
         return Stream.of(
-            Arguments.of(MEMBER_1, LocalDate.of(2020, 8, 8), Arrays.asList(1L, 2L, 3L, 4L)),
-            Arguments.of(MEMBER_2, LocalDate.of(2020, 7, 10), Arrays.asList(16L, 17L, 18L, 19L))
+            Arguments.of(InMemoryScheduleRepository.MEMBER_1, LocalDate.of(2020, 8, 8), Arrays.asList(1L, 2L, 3L, 4L)),
+            Arguments.of(InMemoryScheduleRepository.MEMBER_2, LocalDate.of(2020, 7, 10), Arrays.asList(6L, 7L, 8L, 9L))
         );
     }
 }

--- a/miracle-api/src/test/java/com/depromeet/service/schedule/ScheduleServiceTest.java
+++ b/miracle-api/src/test/java/com/depromeet/service/schedule/ScheduleServiceTest.java
@@ -1,5 +1,6 @@
 package com.depromeet.service.schedule;
 
+import com.depromeet.domain.schedule.LoopType;
 import com.depromeet.service.schedule.dto.GetScheduleResponse;
 import com.depromeet.service.schedule.dto.UpdateScheduleRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -53,7 +54,7 @@ class ScheduleServiceTest {
     @DisplayName("존재하지 않는 스케쥴 수정 시에 예외 발생")
     @Test
     void updateNotExistSchedule_ShouldFail() {
-        UpdateScheduleRequest request = new UpdateScheduleRequest(LocalDateTime.now(), LocalDateTime.now(), "category", "desciption", "loopType");
+        UpdateScheduleRequest request = new UpdateScheduleRequest(LocalDateTime.now(), LocalDateTime.now(), "category", "desciption", LoopType.NONE);
         assertThatThrownBy(() -> {
             service.updateSchedule(InMemoryScheduleRepository.MEMBER_1, 0L, request);
         }).isInstanceOf(NoSuchElementException.class);

--- a/miracle-api/src/test/java/com/depromeet/service/schedule/ScheduleServiceTest.java
+++ b/miracle-api/src/test/java/com/depromeet/service/schedule/ScheduleServiceTest.java
@@ -30,9 +30,9 @@ class ScheduleServiceTest {
 
     @DisplayName("하루 동안의 스케쥴을 조회 할 수 있다")
     @ParameterizedTest
-    @MethodSource("source_getDailySchedule_ShouldSuccess")
-    void getDailySchedule_ShouldSuccess(long memberId, LocalDate date, List<Long> scheduleIds) {
-        List<GetScheduleResponse> response = service.getDailySchedule(memberId, date);
+    @MethodSource("source_retrieveDailySchedule_ShouldSuccess")
+    void retrieveDailySchedule_ShouldSuccess(long memberId, LocalDate date, List<Long> scheduleIds) {
+        List<GetScheduleResponse> response = service.retrieveDailySchedule(memberId, date);
 
         List<Long> result = response
             .stream()
@@ -43,7 +43,7 @@ class ScheduleServiceTest {
         assertThat(scheduleIds.equals(result)).isTrue();
     }
 
-    static Stream<Arguments> source_getDailySchedule_ShouldSuccess() {
+    static Stream<Arguments> source_retrieveDailySchedule_ShouldSuccess() {
         return Stream.of(
             Arguments.of(InMemoryScheduleRepository.MEMBER_1, LocalDate.of(2020, 8, 8), Arrays.asList(1L, 2L, 3L, 4L)),
             Arguments.of(InMemoryScheduleRepository.MEMBER_2, LocalDate.of(2020, 7, 10), Arrays.asList(6L, 7L, 8L, 9L))

--- a/miracle-api/src/test/java/com/depromeet/service/schedule/ScheduleServiceTest.java
+++ b/miracle-api/src/test/java/com/depromeet/service/schedule/ScheduleServiceTest.java
@@ -1,18 +1,23 @@
 package com.depromeet.service.schedule;
 
 import com.depromeet.service.schedule.dto.GetScheduleResponse;
+import com.depromeet.service.schedule.dto.UpdateScheduleRequest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Schedule Service Test")
 class ScheduleServiceTest {
@@ -43,5 +48,14 @@ class ScheduleServiceTest {
             Arguments.of(InMemoryScheduleRepository.MEMBER_1, LocalDate.of(2020, 8, 8), Arrays.asList(1L, 2L, 3L, 4L)),
             Arguments.of(InMemoryScheduleRepository.MEMBER_2, LocalDate.of(2020, 7, 10), Arrays.asList(6L, 7L, 8L, 9L))
         );
+    }
+
+    @DisplayName("존재하지 않는 스케쥴 수정 시에 예외 발생")
+    @Test
+    void updateNotExistSchedule_ShouldFail() {
+        UpdateScheduleRequest request = new UpdateScheduleRequest(LocalDateTime.now(), LocalDateTime.now(), "category", "desciption", "loopType");
+        assertThatThrownBy(() -> {
+            service.updateSchedule(InMemoryScheduleRepository.MEMBER_1, 0L, request);
+        }).isInstanceOf(NoSuchElementException.class);
     }
 }

--- a/miracle-domain/build.gradle
+++ b/miracle-domain/build.gradle
@@ -20,7 +20,7 @@ jar { enabled = true }
 
 dependencies {
     implementation project(':miracle-exception')
-    
+
     api group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '2.2.8.RELEASE'
     implementation("org.mariadb.jdbc:mariadb-java-client")
     runtimeOnly 'mysql:mysql-connector-java'
@@ -28,6 +28,8 @@ dependencies {
 
     implementation("com.querydsl:querydsl-jpa")
     implementation("com.querydsl:querydsl-apt")
+
+    implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 }
 
 configurations {

--- a/miracle-domain/src/main/java/com/depromeet/domain/schedule/IllegalScheduleAccessException.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/schedule/IllegalScheduleAccessException.java
@@ -1,0 +1,7 @@
+package com.depromeet.domain.schedule;
+
+public class IllegalScheduleAccessException extends RuntimeException {
+    public IllegalScheduleAccessException(String message) {
+        super(message);
+    }
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/schedule/LoopType.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/schedule/LoopType.java
@@ -1,8 +1,11 @@
 package com.depromeet.domain.schedule;
 
+import io.swagger.annotations.ApiModel;
+
 import java.util.HashMap;
 import java.util.Map;
 
+@ApiModel
 public enum LoopType {
     NONE("NONE"),
     DAY("DAY"),

--- a/miracle-domain/src/main/java/com/depromeet/domain/schedule/Schedule.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/schedule/Schedule.java
@@ -55,8 +55,8 @@ public class Schedule extends BaseTimeEntity {
         this.loopType = loopType;
     }
 
-    public static Schedule of(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
-        return new Schedule(memberId, startTime, endTime, category, description, LoopType.of(loopType));
+    public static Schedule of(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
+        return new Schedule(memberId, startTime, endTime, category, description, loopType);
     }
 
     private void validateTime(LocalDateTime startTime, LocalDateTime endTime) {

--- a/miracle-domain/src/main/java/com/depromeet/domain/schedule/Schedule.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/schedule/Schedule.java
@@ -68,6 +68,23 @@ public class Schedule extends BaseTimeEntity {
         }
     }
 
+    public void update(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
+        if (this.memberId != memberId) {
+            throw new IllegalScheduleAccessException(String.format("해당 스케쥴 (%d)은 수정할 수 없습니다", this.id));
+        }
+
+        validateTime(startTime, endTime);
+        this.year = startTime.getYear();
+        this.month = startTime.getMonthValue();
+        this.day = startTime.getDayOfMonth();
+        this.dayOfWeek = startTime.getDayOfWeek();
+        this.startTime = startTime.toLocalTime();
+        this.endTime = endTime.toLocalTime();
+        this.category = category;
+        this.description = description;
+        this.loopType = loopType;
+    }
+
     public Long getId() {
         return id;
     }

--- a/miracle-domain/src/main/java/com/depromeet/domain/schedule/repository/ScheduleRepositoryCustom.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/schedule/repository/ScheduleRepositoryCustom.java
@@ -7,11 +7,11 @@ import java.time.DayOfWeek;
 import java.util.List;
 
 public interface ScheduleRepositoryCustom {
-    List<Schedule> getSchedulesByMemberIdAndLoopTypeAndYearAndMonthAndDay(long memberId, LoopType loopType, int year, int month, int day);
+    List<Schedule> findSchedulesByMemberIdAndLoopTypeAndYearAndMonthAndDay(long memberId, LoopType loopType, int year, int month, int day);
 
-    List<Schedule> getSchedulesByMemberIdAndLoopType(long memberId, LoopType loopType);
+    List<Schedule> findSchedulesByMemberIdAndLoopType(long memberId, LoopType loopType);
 
-    List<Schedule> getSchedulesByMemberIdAndLoopTypeAndDayOfWeek(long memberId, LoopType loopType, DayOfWeek dayOfWeek);
+    List<Schedule> findSchedulesByMemberIdAndLoopTypeAndDayOfWeek(long memberId, LoopType loopType, DayOfWeek dayOfWeek);
 
-    List<Schedule> getSchedulesByMemberIdAndLoopTypeAndDay(long memberId, LoopType loopType, int day);
+    List<Schedule> findSchedulesByMemberIdAndLoopTypeAndDay(long memberId, LoopType loopType, int day);
 }

--- a/miracle-domain/src/main/java/com/depromeet/domain/schedule/repository/ScheduleRepositoryCustomImpl.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/schedule/repository/ScheduleRepositoryCustomImpl.java
@@ -20,7 +20,7 @@ public class ScheduleRepositoryCustomImpl implements ScheduleRepositoryCustom {
     }
 
     @Override
-    public List<Schedule> getSchedulesByMemberIdAndLoopTypeAndYearAndMonthAndDay(long memberId, LoopType loopType, int year, int month, int day) {
+    public List<Schedule> findSchedulesByMemberIdAndLoopTypeAndYearAndMonthAndDay(long memberId, LoopType loopType, int year, int month, int day) {
         return queryFactory.selectFrom(schedule)
             .where(
                 schedule.memberId.eq(memberId),
@@ -32,7 +32,7 @@ public class ScheduleRepositoryCustomImpl implements ScheduleRepositoryCustom {
     }
 
     @Override
-    public List<Schedule> getSchedulesByMemberIdAndLoopType(long memberId, LoopType loopType) {
+    public List<Schedule> findSchedulesByMemberIdAndLoopType(long memberId, LoopType loopType) {
         return queryFactory.selectFrom(schedule)
             .where(
                 schedule.memberId.eq(memberId),
@@ -41,7 +41,7 @@ public class ScheduleRepositoryCustomImpl implements ScheduleRepositoryCustom {
     }
 
     @Override
-    public List<Schedule> getSchedulesByMemberIdAndLoopTypeAndDayOfWeek(long memberId, LoopType loopType, DayOfWeek dayOfWeek) {
+    public List<Schedule> findSchedulesByMemberIdAndLoopTypeAndDayOfWeek(long memberId, LoopType loopType, DayOfWeek dayOfWeek) {
         return queryFactory.selectFrom(schedule)
             .where(
                 schedule.memberId.eq(memberId),
@@ -51,7 +51,7 @@ public class ScheduleRepositoryCustomImpl implements ScheduleRepositoryCustom {
     }
 
     @Override
-    public List<Schedule> getSchedulesByMemberIdAndLoopTypeAndDay(long memberId, LoopType loopType, int day) {
+    public List<Schedule> findSchedulesByMemberIdAndLoopTypeAndDay(long memberId, LoopType loopType, int day) {
         return queryFactory.selectFrom(schedule)
             .where(
                 schedule.memberId.eq(memberId),

--- a/miracle-domain/src/test/java/com/depromeet/domain/schedule/ScheduleTest.java
+++ b/miracle-domain/src/test/java/com/depromeet/domain/schedule/ScheduleTest.java
@@ -71,4 +71,46 @@ class ScheduleTest {
             Arguments.of(1L, LocalDateTime.of(2030, 8, 6, 11, 0, 0), LocalDateTime.of(2020, 8, 6, 11, 30, 0), "수면", "취침시간", "WEEK")
         );
     }
+
+    @DisplayName("Schedule 객체를 변경할 수 있다")
+    @ParameterizedTest
+    @MethodSource("source_updateSchedule_ShouldSuccess")
+    void updateSchedule_ShouldSuccess(LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
+        Schedule schedule = Schedule.of(1L, LocalDateTime.of(2020, 8, 6, 8, 0, 0), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", "NONE");
+        schedule.update(schedule.getMemberId(), startTime, endTime, category, description, LoopType.of(loopType));
+        assertAll(
+            () -> assertThat(schedule.getYear()).isEqualTo(startTime.getYear()),
+            () -> assertThat(schedule.getMonth()).isEqualTo(startTime.getMonthValue()),
+            () -> assertThat(schedule.getDay()).isEqualTo(startTime.getDayOfMonth()),
+            () -> assertThat(schedule.getStartTime()).isEqualTo(startTime.toLocalTime()),
+            () -> assertThat(schedule.getEndTime()).isEqualTo(endTime.toLocalTime()),
+            () -> assertThat(schedule.getLoopType()).isEqualTo(LoopType.of(loopType))
+        );
+    }
+
+    static Stream<Arguments> source_updateSchedule_ShouldSuccess() {
+        return Stream.of(
+            Arguments.of(LocalDateTime.of(2020, 8, 6, 6, 0, 0), LocalDateTime.of(2020, 8, 6, 6, 30, 0), "운동", "운동하기", "NONE"),
+            Arguments.of(LocalDateTime.of(2020, 8, 6, 9, 0, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "요가-2", "스트레칭-2", "DAY"),
+            Arguments.of(LocalDateTime.of(2020, 8, 6, 22, 0, 0), LocalDateTime.of(2020, 8, 6, 22, 30, 0), "수면", "취침시간", "MONTH")
+        );
+    }
+
+    @DisplayName("다른 멤버의 스케쥴을 수정 시에 예외 발생")
+    @ParameterizedTest
+    @MethodSource("source_updateSchedule_ShouldFail")
+    void updateSchedule_ShouldFail(LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
+        Schedule schedule = Schedule.of(1L, LocalDateTime.of(2020, 8, 6, 8, 0, 0), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", "NONE");
+        assertThatThrownBy(() -> {
+            schedule.update(schedule.getMemberId() + 1, startTime, endTime, category, description, LoopType.of(loopType));
+        }).isInstanceOf(IllegalScheduleAccessException.class);
+    }
+
+    static Stream<Arguments> source_updateSchedule_ShouldFail() {
+        return Stream.of(
+            Arguments.of(LocalDateTime.of(2020, 8, 6, 6, 0, 0), LocalDateTime.of(2020, 8, 6, 6, 30, 0), "운동", "운동하기", "NONE"),
+            Arguments.of(LocalDateTime.of(2020, 8, 6, 9, 0, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "요가-2", "스트레칭-2", "DAY"),
+            Arguments.of(LocalDateTime.of(2020, 8, 6, 22, 0, 0), LocalDateTime.of(2020, 8, 6, 22, 30, 0), "수면", "취침시간", "MONTH")
+        );
+    }
 }

--- a/miracle-domain/src/test/java/com/depromeet/domain/schedule/ScheduleTest.java
+++ b/miracle-domain/src/test/java/com/depromeet/domain/schedule/ScheduleTest.java
@@ -18,7 +18,7 @@ class ScheduleTest {
     @DisplayName("Schedule 객체를 생성할 수 있다")
     @ParameterizedTest
     @MethodSource("source_createSchedule_ShouldSuccess")
-    void createSchedule_ShouldSuccess(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
+    void createSchedule_ShouldSuccess(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
         Schedule schedule = Schedule.of(memberId, startTime, endTime, category, description, loopType);
         assertAll(
             () -> assertThat(schedule.getYear()).isEqualTo(startTime.getYear()),
@@ -26,22 +26,22 @@ class ScheduleTest {
             () -> assertThat(schedule.getDay()).isEqualTo(startTime.getDayOfMonth()),
             () -> assertThat(schedule.getStartTime()).isEqualTo(startTime.toLocalTime()),
             () -> assertThat(schedule.getEndTime()).isEqualTo(endTime.toLocalTime()),
-            () -> assertThat(schedule.getLoopType()).isEqualTo(LoopType.of(loopType))
+            () -> assertThat(schedule.getLoopType()).isEqualTo(loopType)
         );
     }
 
     static Stream<Arguments> source_createSchedule_ShouldSuccess() {
         return Stream.of(
-            Arguments.of(1L, LocalDateTime.of(2020, 8, 6, 8, 0, 0), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", "NONE"),
-            Arguments.of(2L, LocalDateTime.of(2020, 8, 6, 9, 0, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "요가", "스트레칭", "DAY"),
-            Arguments.of(3L, LocalDateTime.of(2020, 8, 6, 22, 0, 0), LocalDateTime.of(2020, 8, 6, 22, 30, 0), "수면", "취침시간", "WEEK")
+            Arguments.of(1L, LocalDateTime.of(2020, 8, 6, 8, 0, 0), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", LoopType.NONE),
+            Arguments.of(2L, LocalDateTime.of(2020, 8, 6, 9, 0, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "요가", "스트레칭", LoopType.DAY),
+            Arguments.of(3L, LocalDateTime.of(2020, 8, 6, 22, 0, 0), LocalDateTime.of(2020, 8, 6, 22, 30, 0), "수면", "취침시간", LoopType.WEEK)
         );
     }
 
     @DisplayName("시작시간이 종료시간 이후라면 예외 발생")
     @ParameterizedTest
     @MethodSource("source_startTimeAfterEndTime_ShouldFail")
-    void startTimeAfterEndTime_ShouldFail(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
+    void startTimeAfterEndTime_ShouldFail(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
         assertThatThrownBy(() -> {
             Schedule.of(memberId, startTime, endTime, category, description, loopType);
         }).isInstanceOf(InvalidScheduleTimeException.class);
@@ -49,16 +49,16 @@ class ScheduleTest {
 
     static Stream<Arguments> source_startTimeAfterEndTime_ShouldFail() {
         return Stream.of(
-            Arguments.of(1L, LocalDateTime.of(2020, 8, 6, 8, 30, 10), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", "NONE"),
-            Arguments.of(1L, LocalDateTime.of(2020, 8, 6, 10, 10, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "운동", "스트레칭", "DAY"),
-            Arguments.of(1L, LocalDateTime.of(2020, 8, 6, 13, 30, 0), LocalDateTime.of(2020, 8, 6, 11, 30, 0), "수면", "취침시간", "WEEK")
+            Arguments.of(1L, LocalDateTime.of(2020, 8, 6, 8, 30, 10), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", LoopType.NONE),
+            Arguments.of(1L, LocalDateTime.of(2020, 8, 6, 10, 10, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "운동", "스트레칭", LoopType.DAY),
+            Arguments.of(1L, LocalDateTime.of(2020, 8, 6, 13, 30, 0), LocalDateTime.of(2020, 8, 6, 11, 30, 0), "수면", "취침시간", LoopType.WEEK)
         );
     }
 
     @DisplayName("시작시간과 종료시간이 같은 날짜가 아니라면 예외 발생")
     @ParameterizedTest
     @MethodSource("source_startTimeAndEndTimeNotSame_ShouldFail")
-    void startTimeAndEndTimeNotSame_ShouldFail(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
+    void startTimeAndEndTimeNotSame_ShouldFail(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
         assertThatThrownBy(() -> {
             Schedule.of(memberId, startTime, endTime, category, description, loopType);
         }).isInstanceOf(InvalidScheduleTimeException.class);
@@ -66,51 +66,51 @@ class ScheduleTest {
 
     static Stream<Arguments> source_startTimeAndEndTimeNotSame_ShouldFail() {
         return Stream.of(
-            Arguments.of(1L, LocalDateTime.of(2020, 8, 7, 8, 0, 0), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", "NONE"),
-            Arguments.of(1L, LocalDateTime.of(2020, 9, 6, 9, 0, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "운동", "스트레칭", "DAY"),
-            Arguments.of(1L, LocalDateTime.of(2030, 8, 6, 11, 0, 0), LocalDateTime.of(2020, 8, 6, 11, 30, 0), "수면", "취침시간", "WEEK")
+            Arguments.of(1L, LocalDateTime.of(2020, 8, 7, 8, 0, 0), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", LoopType.NONE),
+            Arguments.of(1L, LocalDateTime.of(2020, 9, 6, 9, 0, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "운동", "스트레칭", LoopType.DAY),
+            Arguments.of(1L, LocalDateTime.of(2030, 8, 6, 11, 0, 0), LocalDateTime.of(2020, 8, 6, 11, 30, 0), "수면", "취침시간", LoopType.WEEK)
         );
     }
 
     @DisplayName("Schedule 객체를 변경할 수 있다")
     @ParameterizedTest
     @MethodSource("source_updateSchedule_ShouldSuccess")
-    void updateSchedule_ShouldSuccess(LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
-        Schedule schedule = Schedule.of(1L, LocalDateTime.of(2020, 8, 6, 8, 0, 0), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", "NONE");
-        schedule.update(schedule.getMemberId(), startTime, endTime, category, description, LoopType.of(loopType));
+    void updateSchedule_ShouldSuccess(LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
+        Schedule schedule = Schedule.of(1L, LocalDateTime.of(2020, 8, 6, 8, 0, 0), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", LoopType.NONE);
+        schedule.update(schedule.getMemberId(), startTime, endTime, category, description, loopType);
         assertAll(
             () -> assertThat(schedule.getYear()).isEqualTo(startTime.getYear()),
             () -> assertThat(schedule.getMonth()).isEqualTo(startTime.getMonthValue()),
             () -> assertThat(schedule.getDay()).isEqualTo(startTime.getDayOfMonth()),
             () -> assertThat(schedule.getStartTime()).isEqualTo(startTime.toLocalTime()),
             () -> assertThat(schedule.getEndTime()).isEqualTo(endTime.toLocalTime()),
-            () -> assertThat(schedule.getLoopType()).isEqualTo(LoopType.of(loopType))
+            () -> assertThat(schedule.getLoopType()).isEqualTo(loopType)
         );
     }
 
     static Stream<Arguments> source_updateSchedule_ShouldSuccess() {
         return Stream.of(
-            Arguments.of(LocalDateTime.of(2020, 8, 6, 6, 0, 0), LocalDateTime.of(2020, 8, 6, 6, 30, 0), "운동", "운동하기", "NONE"),
-            Arguments.of(LocalDateTime.of(2020, 8, 6, 9, 0, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "요가-2", "스트레칭-2", "DAY"),
-            Arguments.of(LocalDateTime.of(2020, 8, 6, 22, 0, 0), LocalDateTime.of(2020, 8, 6, 22, 30, 0), "수면", "취침시간", "MONTH")
+            Arguments.of(LocalDateTime.of(2020, 8, 6, 6, 0, 0), LocalDateTime.of(2020, 8, 6, 6, 30, 0), "운동", "운동하기", LoopType.NONE),
+            Arguments.of(LocalDateTime.of(2020, 8, 6, 9, 0, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "요가-2", "스트레칭-2", LoopType.DAY),
+            Arguments.of(LocalDateTime.of(2020, 8, 6, 22, 0, 0), LocalDateTime.of(2020, 8, 6, 22, 30, 0), "수면", "취침시간", LoopType.MONTH)
         );
     }
 
     @DisplayName("다른 멤버의 스케쥴을 수정 시에 예외 발생")
     @ParameterizedTest
     @MethodSource("source_updateSchedule_ShouldFail")
-    void updateSchedule_ShouldFail(LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
-        Schedule schedule = Schedule.of(1L, LocalDateTime.of(2020, 8, 6, 8, 0, 0), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", "NONE");
+    void updateSchedule_ShouldFail(LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
+        Schedule schedule = Schedule.of(1L, LocalDateTime.of(2020, 8, 6, 8, 0, 0), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", LoopType.NONE);
         assertThatThrownBy(() -> {
-            schedule.update(schedule.getMemberId() + 1, startTime, endTime, category, description, LoopType.of(loopType));
+            schedule.update(schedule.getMemberId() + 1, startTime, endTime, category, description, loopType);
         }).isInstanceOf(IllegalScheduleAccessException.class);
     }
 
     static Stream<Arguments> source_updateSchedule_ShouldFail() {
         return Stream.of(
-            Arguments.of(LocalDateTime.of(2020, 8, 6, 6, 0, 0), LocalDateTime.of(2020, 8, 6, 6, 30, 0), "운동", "운동하기", "NONE"),
-            Arguments.of(LocalDateTime.of(2020, 8, 6, 9, 0, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "요가-2", "스트레칭-2", "DAY"),
-            Arguments.of(LocalDateTime.of(2020, 8, 6, 22, 0, 0), LocalDateTime.of(2020, 8, 6, 22, 30, 0), "수면", "취침시간", "MONTH")
+            Arguments.of(LocalDateTime.of(2020, 8, 6, 6, 0, 0), LocalDateTime.of(2020, 8, 6, 6, 30, 0), "운동", "운동하기", LoopType.NONE),
+            Arguments.of(LocalDateTime.of(2020, 8, 6, 9, 0, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "요가-2", "스트레칭-2", LoopType.DAY),
+            Arguments.of(LocalDateTime.of(2020, 8, 6, 22, 0, 0), LocalDateTime.of(2020, 8, 6, 22, 30, 0), "수면", "취침시간", LoopType.MONTH)
         );
     }
 }

--- a/miracle-domain/src/test/java/com/depromeet/domain/schedule/ScheduleTest.java
+++ b/miracle-domain/src/test/java/com/depromeet/domain/schedule/ScheduleTest.java
@@ -18,7 +18,7 @@ class ScheduleTest {
     @DisplayName("Schedule 객체를 생성할 수 있다")
     @ParameterizedTest
     @MethodSource("source_createSchedule_ShouldSuccess")
-    public void createSchedule_ShouldSuccess(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
+    void createSchedule_ShouldSuccess(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
         Schedule schedule = Schedule.of(memberId, startTime, endTime, category, description, loopType);
         assertAll(
             () -> assertThat(schedule.getYear()).isEqualTo(startTime.getYear()),
@@ -30,24 +30,24 @@ class ScheduleTest {
         );
     }
 
-    public static Stream<Arguments> source_createSchedule_ShouldSuccess() {
+    static Stream<Arguments> source_createSchedule_ShouldSuccess() {
         return Stream.of(
             Arguments.of(1L, LocalDateTime.of(2020, 8, 6, 8, 0, 0), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", "NONE"),
-            Arguments.of(1L, LocalDateTime.of(2020, 8, 6, 9, 0, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "운동", "스트레칭", "DAY"),
-            Arguments.of(1L, LocalDateTime.of(2020, 8, 6, 11, 0, 0), LocalDateTime.of(2020, 8, 6, 11, 30, 0), "수면", "취침시간", "WEEK")
+            Arguments.of(2L, LocalDateTime.of(2020, 8, 6, 9, 0, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "요가", "스트레칭", "DAY"),
+            Arguments.of(3L, LocalDateTime.of(2020, 8, 6, 22, 0, 0), LocalDateTime.of(2020, 8, 6, 22, 30, 0), "수면", "취침시간", "WEEK")
         );
     }
 
     @DisplayName("시작시간이 종료시간 이후라면 예외 발생")
     @ParameterizedTest
     @MethodSource("source_startTimeAfterEndTime_ShouldFail")
-    public void startTimeAfterEndTime_ShouldFail(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
+    void startTimeAfterEndTime_ShouldFail(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
         assertThatThrownBy(() -> {
             Schedule.of(memberId, startTime, endTime, category, description, loopType);
         }).isInstanceOf(InvalidScheduleTimeException.class);
     }
 
-    public static Stream<Arguments> source_startTimeAfterEndTime_ShouldFail() {
+    static Stream<Arguments> source_startTimeAfterEndTime_ShouldFail() {
         return Stream.of(
             Arguments.of(1L, LocalDateTime.of(2020, 8, 6, 8, 30, 10), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", "NONE"),
             Arguments.of(1L, LocalDateTime.of(2020, 8, 6, 10, 10, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "운동", "스트레칭", "DAY"),
@@ -58,13 +58,13 @@ class ScheduleTest {
     @DisplayName("시작시간과 종료시간이 같은 날짜가 아니라면 예외 발생")
     @ParameterizedTest
     @MethodSource("source_startTimeAndEndTimeNotSame_ShouldFail")
-    public void startTimeAndEndTimeNotSame_ShouldFail(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
+    void startTimeAndEndTimeNotSame_ShouldFail(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, String loopType) {
         assertThatThrownBy(() -> {
             Schedule.of(memberId, startTime, endTime, category, description, loopType);
         }).isInstanceOf(InvalidScheduleTimeException.class);
     }
 
-    public static Stream<Arguments> source_startTimeAndEndTimeNotSame_ShouldFail() {
+    static Stream<Arguments> source_startTimeAndEndTimeNotSame_ShouldFail() {
         return Stream.of(
             Arguments.of(1L, LocalDateTime.of(2020, 8, 7, 8, 0, 0), LocalDateTime.of(2020, 8, 6, 8, 30, 0), "운동", "운동하기", "NONE"),
             Arguments.of(1L, LocalDateTime.of(2020, 9, 6, 9, 0, 0), LocalDateTime.of(2020, 8, 6, 10, 0, 0), "운동", "스트레칭", "DAY"),


### PR DESCRIPTION
스케쥴 수정 API 추가했습니다
* PUT {{host}}/api/v1/schedule/{{SCHEDULE_ID}}
* 제약사항
  * 존재하지 않는 스케쥴 수정 불가
  * 타인의 스케쥴 수정 불가

기존에 ScheduleService 테스트 시에 ScheduleRepository 에 대한 의존성이 있었고, H2 데이터베이스 연동을 위해 @SpringBootTest 통합 테스트를 진행할 수 밖에 없었습니다.
위의 제약사항을 풀기 위해서 테스트용도의 Mocking 클래스인 InMemoryScheduleRepository 를 구현했습니다.
JpaRepository 를 상속받다보니 구현해야할 다른 메소드들이 불필요하게 추가된 점이 있는데, 이 부분의 개선은 좀 더 고민이 필요합니다