### PR TITLE
feat: Exception Handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ generated/
 
 ### OAuth credentials ###
 application-oauth.yml
+
+## logging file ###
+logs/**

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 def javaProjects = [
     project(':miracle-api'),
-    project(':miracle-domain')
+    project(':miracle-domain'),
+    project(':miracle-exception')
 ]
 
 buildscript {

--- a/miracle-api/build.gradle
+++ b/miracle-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation project(':miracle-domain')
+    implementation project(':miracle-exception')
 
     implementation 'org.springframework.boot:spring-boot-configuration-processor'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/miracle-api/src/main/java/com/depromeet/config/advice/ExceptionControllerAdvice.java
+++ b/miracle-api/src/main/java/com/depromeet/config/advice/ExceptionControllerAdvice.java
@@ -1,0 +1,47 @@
+package com.depromeet.config.advice;
+
+import com.depromeet.ApiResponse;
+import com.deprommet.exception.ConflictException;
+import com.deprommet.exception.InvalidSessionException;
+import com.deprommet.exception.NotFoundException;
+import com.deprommet.exception.ValidationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.depromeet.controller")
+public class ExceptionControllerAdvice {
+
+    @ExceptionHandler(NotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ApiResponse<Object> notFoundException(NotFoundException e) {
+        return new ApiResponse<>("NOT_FOUND_EXCEPTION", e.getMessage(), null);
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ApiResponse<Object> conflictException(ConflictException e) {
+        return new ApiResponse<>("CONFLICT_EXCEPTION", e.getMessage(), null);
+    }
+
+    @ExceptionHandler(InvalidSessionException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ApiResponse<Object> invalidSessionException(InvalidSessionException e) {
+        return new ApiResponse<>("INVALID_SESSION_EXCEPTION", e.getMessage(), null);
+    }
+
+    @ExceptionHandler(ValidationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<Object> validationException(ValidationException e) {
+        return new ApiResponse<>("VALIDATION_EXCEPTION", e.getMessage(), null);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<Object> methodArgumentNotValidException(MethodArgumentNotValidException e) {
+        return new ApiResponse<>("BAD_REQUEST_EXCEPTION", e.getBindingResult().getAllErrors().get(0).getDefaultMessage(), null);
+    }
+
+}

--- a/miracle-api/src/main/java/com/depromeet/config/advice/ExceptionControllerAdvice.java
+++ b/miracle-api/src/main/java/com/depromeet/config/advice/ExceptionControllerAdvice.java
@@ -5,42 +5,49 @@ import com.deprommet.exception.ConflictException;
 import com.deprommet.exception.InvalidSessionException;
 import com.deprommet.exception.NotFoundException;
 import com.deprommet.exception.ValidationException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice(basePackages = "com.depromeet.controller")
 public class ExceptionControllerAdvice {
 
     @ExceptionHandler(NotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ApiResponse<Object> notFoundException(NotFoundException e) {
-        return new ApiResponse<>("NOT_FOUND_EXCEPTION", e.getMessage(), null);
+        log.error(e.getMessage(), e);
+        return new ApiResponse<>("NOT_FOUND_EXCEPTION", e.getClientMessage(), null);
     }
 
     @ExceptionHandler(ConflictException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     public ApiResponse<Object> conflictException(ConflictException e) {
-        return new ApiResponse<>("CONFLICT_EXCEPTION", e.getMessage(), null);
+        log.error(e.getMessage(), e);
+        return new ApiResponse<>("CONFLICT_EXCEPTION", e.getClientMessage(), null);
     }
 
     @ExceptionHandler(InvalidSessionException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public ApiResponse<Object> invalidSessionException(InvalidSessionException e) {
-        return new ApiResponse<>("INVALID_SESSION_EXCEPTION", e.getMessage(), null);
+        log.error(e.getMessage(), e);
+        return new ApiResponse<>("INVALID_SESSION_EXCEPTION", e.getClientMessage(), null);
     }
 
     @ExceptionHandler(ValidationException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ApiResponse<Object> validationException(ValidationException e) {
-        return new ApiResponse<>("VALIDATION_EXCEPTION", e.getMessage(), null);
+        log.error(e.getMessage(), e);
+        return new ApiResponse<>("VALIDATION_EXCEPTION", e.getClientMessage(), null);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ApiResponse<Object> methodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error(e.getMessage(), e);
         return new ApiResponse<>("BAD_REQUEST_EXCEPTION", e.getBindingResult().getAllErrors().get(0).getDefaultMessage(), null);
     }
 

--- a/miracle-api/src/main/java/com/depromeet/config/resolver/LoginMemberArgumentResolver.java
+++ b/miracle-api/src/main/java/com/depromeet/config/resolver/LoginMemberArgumentResolver.java
@@ -2,7 +2,9 @@ package com.depromeet.config.resolver;
 
 import com.depromeet.config.session.MemberSession;
 import com.depromeet.constants.SessionConstants;
+import com.deprommet.exception.InvalidSessionException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.session.Session;
@@ -13,7 +15,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
@@ -40,17 +42,20 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
         validateAvailableHeader(header);
         Session session = sessionRepository.getSession(header.split(BEARER_TOKEN)[1]);
         if (session == null) {
-            throw new IllegalArgumentException(String.format("잘못된 세션입니다 (%s)", header));
+            log.info(String.format("잘못된 세션입니다 (%s)", header));
+            throw new InvalidSessionException("세션이 만료되었습니다. 다시 로그인 해주세요.");
         }
         return session;
     }
 
     private void validateAvailableHeader(String header) {
         if (header == null) {
-            throw new IllegalArgumentException("세션이 없습니다");
+            log.info("세션이 없습니다");
+            throw new InvalidSessionException("세션이 만료되었습니다. 다시 로그인 해주세요.");
         }
         if (!header.startsWith(BEARER_TOKEN)) {
-            throw new IllegalArgumentException(String.format("잘못된 세션입니다 (%s)", header));
+            log.info(String.format("잘못된 세션입니다 (%s)", header));
+            throw new InvalidSessionException("세션이 만료되었습니다. 다시 로그인 해주세요.");
         }
     }
 

--- a/miracle-api/src/main/java/com/depromeet/config/resolver/LoginMemberArgumentResolver.java
+++ b/miracle-api/src/main/java/com/depromeet/config/resolver/LoginMemberArgumentResolver.java
@@ -4,7 +4,6 @@ import com.depromeet.config.session.MemberSession;
 import com.depromeet.constants.SessionConstants;
 import com.deprommet.exception.InvalidSessionException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.session.Session;
@@ -15,7 +14,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-@Slf4j
 @RequiredArgsConstructor
 @Component
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
@@ -42,20 +40,17 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
         validateAvailableHeader(header);
         Session session = sessionRepository.getSession(header.split(BEARER_TOKEN)[1]);
         if (session == null) {
-            log.info(String.format("잘못된 세션입니다 (%s)", header));
-            throw new InvalidSessionException("세션이 만료되었습니다. 다시 로그인 해주세요.");
+            throw new InvalidSessionException(String.format("잘못된 세션입니다 (%s)", header), "세션이 만료되었습니다. 다시 로그인 해주세요.");
         }
         return session;
     }
 
     private void validateAvailableHeader(String header) {
         if (header == null) {
-            log.info("세션이 없습니다");
-            throw new InvalidSessionException("세션이 만료되었습니다. 다시 로그인 해주세요.");
+            throw new InvalidSessionException("세션이 없습니다", "세션이 만료되었습니다. 다시 로그인 해주세요.");
         }
         if (!header.startsWith(BEARER_TOKEN)) {
-            log.info(String.format("잘못된 세션입니다 (%s)", header));
-            throw new InvalidSessionException("세션이 만료되었습니다. 다시 로그인 해주세요.");
+            throw new InvalidSessionException(String.format("잘못된 세션입니다 (%s)", header), "세션이 만료되었습니다. 다시 로그인 해주세요.");
         }
     }
 

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
@@ -2,16 +2,20 @@ package com.depromeet.service.alarm;
 
 import com.depromeet.domain.alarm.AlarmSchedule;
 import com.depromeet.domain.alarm.AlarmScheduleRepository;
+import com.deprommet.exception.NotFoundException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 class AlarmServiceUtils {
 
     static AlarmSchedule findAlarmScheduleByIdAndMemberId(AlarmScheduleRepository alarmScheduleRepository, Long alarmScheduleId, Long memberId) {
         AlarmSchedule alarmSchedule = alarmScheduleRepository.findAlarmScheduleByIdAndMemberId(alarmScheduleId, memberId);
         if (alarmSchedule == null) {
-            throw new IllegalArgumentException(String.format("멤버 (%s) 에게 AlarmSchedule (%s) 은 존재하지 않습니다", memberId, alarmScheduleId));
+            log.info(String.format("멤버 (%s) 에게 AlarmSchedule (%s) 은 존재하지 않습니다", memberId, alarmScheduleId));
+            throw new NotFoundException("해당 알람 스케쥴을 찾을 수 없습니다");
         }
         return alarmSchedule;
     }

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmServiceUtils.java
@@ -5,17 +5,14 @@ import com.depromeet.domain.alarm.AlarmScheduleRepository;
 import com.deprommet.exception.NotFoundException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 class AlarmServiceUtils {
 
     static AlarmSchedule findAlarmScheduleByIdAndMemberId(AlarmScheduleRepository alarmScheduleRepository, Long alarmScheduleId, Long memberId) {
         AlarmSchedule alarmSchedule = alarmScheduleRepository.findAlarmScheduleByIdAndMemberId(alarmScheduleId, memberId);
         if (alarmSchedule == null) {
-            log.info(String.format("멤버 (%s) 에게 AlarmSchedule (%s) 은 존재하지 않습니다", memberId, alarmScheduleId));
-            throw new NotFoundException("해당 알람 스케쥴을 찾을 수 없습니다");
+            throw new NotFoundException(String.format("멤버 (%s) 에게 AlarmSchedule (%s) 은 존재하지 않습니다", memberId, alarmScheduleId), "해당 알람 스케쥴을 찾을 수 없습니다");
         }
         return alarmSchedule;
     }

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/AlarmRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/AlarmRequest.java
@@ -13,10 +13,10 @@ import java.time.LocalTime;
 @NoArgsConstructor
 public class AlarmRequest {
 
-    @NotNull
+    @NotNull(message = "알람을 받을 요일을 선택해주세요.")
     private DayOfTheWeek dayOfTheWeek;
 
-    @NotNull
+    @NotNull(message = "알람을 받을 시간을 입력해주세요.")
     private LocalTime reminderTime;
 
     @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/CreateAlarmScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/CreateAlarmScheduleRequest.java
@@ -17,10 +17,10 @@ public class CreateAlarmScheduleRequest {
 
     private String description;
 
-    @NotNull
+    @NotNull(message = "알람의 종류를 입력해주세요.")
     private AlarmType type;
 
-    @NotNull
+    @NotNull(message = "알람 리스트를 입력해주세요.")
     private List<AlarmRequest> alarms;
 
     @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/DeleteAlarmScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/DeleteAlarmScheduleRequest.java
@@ -9,7 +9,7 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 public class DeleteAlarmScheduleRequest {
 
-    @NotNull
+    @NotNull(message = "삭제하려는 알람 스케쥴의 아이디를 입력해주세요.")
     private Long alarmScheduleId;
 
     private DeleteAlarmScheduleRequest(Long alarmScheduleId) {

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/RetrieveAlarmScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/RetrieveAlarmScheduleRequest.java
@@ -9,7 +9,7 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 public class RetrieveAlarmScheduleRequest {
 
-    @NotNull
+    @NotNull(message = "조회하려는 알람 스케쥴의 아이디를 입력해주세요.")
     private Long alarmScheduleId;
 
     private RetrieveAlarmScheduleRequest(Long alarmScheduleId) {

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/UpdateAlarmScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/dto/request/UpdateAlarmScheduleRequest.java
@@ -15,15 +15,15 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 public class UpdateAlarmScheduleRequest {
 
-    @NotNull
+    @NotNull(message = "수정하려는 알람 스케쥴의 아이디를 입력해주세요.")
     private Long alarmScheduleId;
 
-    @NotNull
+    @NotNull(message = "알람의 종류를 입력해주세요.")
     private AlarmType type;
 
     private String description;
 
-    @NotNull
+    @NotNull(message = "알람 리스트를 입력해주세요.")
     private List<AlarmRequest> alarms;
 
     @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")

--- a/miracle-api/src/main/java/com/depromeet/service/authentication/dto/request/GoogleOAuthRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/authentication/dto/request/GoogleOAuthRequest.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotBlank;
 @NoArgsConstructor
 public class GoogleOAuthRequest {
 
-    @NotBlank
+    @NotBlank(message = "Code를 입력해주세요.")
     private String code;
 
     @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")

--- a/miracle-api/src/main/java/com/depromeet/service/member/MemberServiceUtils.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/MemberServiceUtils.java
@@ -2,22 +2,28 @@ package com.depromeet.service.member;
 
 import com.depromeet.domain.member.Member;
 import com.depromeet.domain.member.MemberRepository;
+import com.deprommet.exception.ConflictException;
+import com.deprommet.exception.NotFoundException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 class MemberServiceUtils {
 
     static void validateNonExistMember(MemberRepository memberRepository, String email) {
         if (memberRepository.findMemberByEmail(email) != null) {
-            throw new IllegalArgumentException(String.format("이미 존재하는 멤버 (%s) 입니다", email));
+            log.info(String.format("이미 가입한 멤버 (%s) 입니다", email));
+            throw new ConflictException("이미 가입한 멤버입니다");
         }
     }
 
     static Member findMemberById(MemberRepository memberRepository, Long memberId) {
         Member member = memberRepository.findMemberById(memberId);
         if (member == null) {
-            throw new IllegalArgumentException(String.format("멤버 (%s)는 존재하지 않습니다", memberId));
+            log.info(String.format("해당 멤버 (%s)는 존재하지 않습니다", memberId));
+            throw new NotFoundException("해당 멤버를 찾을 수 없습니다");
         }
         return member;
     }

--- a/miracle-api/src/main/java/com/depromeet/service/member/MemberServiceUtils.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/MemberServiceUtils.java
@@ -6,24 +6,20 @@ import com.deprommet.exception.ConflictException;
 import com.deprommet.exception.NotFoundException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 class MemberServiceUtils {
 
     static void validateNonExistMember(MemberRepository memberRepository, String email) {
         if (memberRepository.findMemberByEmail(email) != null) {
-            log.info(String.format("이미 가입한 멤버 (%s) 입니다", email));
-            throw new ConflictException("이미 가입한 멤버입니다");
+            throw new ConflictException(String.format("이미 가입한 멤버 (%s) 입니다", email), "이미 가입한 멤버입니다");
         }
     }
 
     static Member findMemberById(MemberRepository memberRepository, Long memberId) {
         Member member = memberRepository.findMemberById(memberId);
         if (member == null) {
-            log.info(String.format("해당 멤버 (%s)는 존재하지 않습니다", memberId));
-            throw new NotFoundException("해당 멤버를 찾을 수 없습니다");
+            throw new NotFoundException(String.format("해당 멤버 (%s)는 존재하지 않습니다", memberId), "해당 멤버를 찾을 수 없습니다");
         }
         return member;
     }

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/request/SignUpMemberRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/request/SignUpMemberRequest.java
@@ -17,20 +17,20 @@ import java.util.List;
 @NoArgsConstructor
 public class SignUpMemberRequest {
 
-    @NotBlank
+    @NotBlank(message = "이메일을 입력해주세요.")
     private String email;
 
-    @NotBlank
+    @NotBlank(message = "닉네임을 입력해주세요")
     private String name;
 
-    @NotNull
+    @NotNull(message = "프로필 아이콘을 선택해주세요.")
     private ProfileIcon profileIcon;
 
-    @NotNull
-    @Size(max = 3)
+    @NotNull(message = "목표를 설정해주세요.")
+    @Size(max = 3, message = "목표를 3개 이하 선택해주세요.")
     private List<Category> goals;
 
-    @NotNull
+    @NotNull(message = "기상시간을 입력해주세요.")
     private LocalTime wakeUpTime;
 
     @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberGoalsRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberGoalsRequest.java
@@ -12,8 +12,8 @@ import java.util.List;
 @NoArgsConstructor
 public class UpdateMemberGoalsRequest {
 
-    @NotNull
-    @Size(max = 3)
+    @NotNull(message = "목표를 설정해주세요.")
+    @Size(max = 3, message = "목표를 3개 이하 선택해주세요.")
     private List<Category> goals;
 
     private UpdateMemberGoalsRequest(List<Category> goals) {

--- a/miracle-api/src/main/resources/application-logging.yml
+++ b/miracle-api/src/main/resources/application-logging.yml
@@ -1,0 +1,15 @@
+---
+spring:
+    profiles: local
+logging:
+    file:
+        path: logs/
+        max-size: 10MB
+
+---
+spring:
+    profiles: prod
+logging:
+    file:
+        path: logs/
+        max-size: 100MB

--- a/miracle-api/src/main/resources/application.properties
+++ b/miracle-api/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 spring.profiles.active=local
-spring.profiles.include=domain, oauth
+spring.profiles.include=domain, oauth, logging
 server.port=8080
 spring.datasource.data=classpath:schema/schema-session.sql

--- a/miracle-api/src/test/java/com/depromeet/service/alarm/AlarmServiceTest.java
+++ b/miracle-api/src/test/java/com/depromeet/service/alarm/AlarmServiceTest.java
@@ -15,6 +15,7 @@ import com.depromeet.service.alarm.dto.request.DeleteAlarmScheduleRequest;
 import com.depromeet.service.alarm.dto.request.RetrieveAlarmScheduleRequest;
 import com.depromeet.service.alarm.dto.request.UpdateAlarmScheduleRequest;
 import com.depromeet.service.alarm.dto.response.AlarmScheduleInfoResponse;
+import com.deprommet.exception.NotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -186,7 +187,7 @@ class AlarmServiceTest extends MemberSetup {
         // when & then
         assertThatThrownBy(() -> {
             alarmService.retrieveAlarmSchedule(request, 999L);
-        }).isInstanceOf(IllegalArgumentException.class);
+        }).isInstanceOf(NotFoundException.class);
     }
 
     @Test

--- a/miracle-api/src/test/java/com/depromeet/service/member/MemberServiceTest.java
+++ b/miracle-api/src/test/java/com/depromeet/service/member/MemberServiceTest.java
@@ -16,6 +16,8 @@ import com.depromeet.service.member.dto.request.SignUpMemberRequest;
 import com.depromeet.service.member.dto.request.UpdateMemberGoalsRequest;
 import com.depromeet.service.member.dto.request.UpdateMemberInfoRequest;
 import com.depromeet.service.member.dto.response.MemberInfoResponse;
+import com.deprommet.exception.ConflictException;
+import com.deprommet.exception.NotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -140,7 +142,7 @@ class MemberServiceTest {
         // when & then
         assertThatThrownBy(() -> {
             memberService.signUpMember(request);
-        }).isInstanceOf(IllegalArgumentException.class);
+        }).isInstanceOf(ConflictException.class);
     }
 
     @Test
@@ -199,7 +201,7 @@ class MemberServiceTest {
         // when & then
         assertThatThrownBy(() -> {
             memberService.updateMemberInfo(request, 999L);
-        }).isInstanceOf(IllegalArgumentException.class);
+        }).isInstanceOf(NotFoundException.class);
     }
 
     @Test
@@ -252,7 +254,7 @@ class MemberServiceTest {
         // when & then
         assertThatThrownBy(() -> {
             memberService.getMemberInfo(999L);
-        }).isInstanceOf(IllegalArgumentException.class);
+        }).isInstanceOf(NotFoundException.class);
     }
 
     private void assertMemberInfoResponse(MemberInfoResponse response, String email, String name, ProfileIcon profileIcon) {

--- a/miracle-domain/build.gradle
+++ b/miracle-domain/build.gradle
@@ -19,6 +19,8 @@ bootJar { enabled = false }
 jar { enabled = true }
 
 dependencies {
+    implementation project(':miracle-exception')
+    
     api group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '2.2.8.RELEASE'
     runtimeOnly 'com.h2database:h2'
 

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/Email.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/Email.java
@@ -4,14 +4,12 @@ import com.deprommet.exception.ValidationException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-@Slf4j
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
@@ -29,8 +27,7 @@ public class Email {
 
     private void verifyEmailFormat(String email) {
         if (!EMAIL_REGEX.matcher(email).matches()) {
-            log.info(String.format("(%s)은 이메일 포맷에 맞지 않습니다", email));
-            throw new ValidationException("잘못된 이메일 형식입니다");
+            throw new ValidationException(String.format("(%s)은 이메일 포맷에 맞지 않습니다", email), "잘못된 이메일 형식입니다");
         }
     }
 

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/Email.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/Email.java
@@ -1,14 +1,17 @@
 package com.depromeet.domain.member;
 
+import com.deprommet.exception.ValidationException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
+@Slf4j
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
@@ -26,7 +29,8 @@ public class Email {
 
     private void verifyEmailFormat(String email) {
         if (!EMAIL_REGEX.matcher(email).matches()) {
-            throw new IllegalArgumentException(String.format("(%s)은  이메일 포맷에 맞지 않습니다", email));
+            log.info(String.format("(%s)은 이메일 포맷에 맞지 않습니다", email));
+            throw new ValidationException("잘못된 이메일 형식입니다");
         }
     }
 

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/Member.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/Member.java
@@ -7,7 +7,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 
 import javax.persistence.CascadeType;
@@ -22,7 +21,6 @@ import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 
-@Slf4j
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -107,8 +105,7 @@ public class Member extends BaseTimeEntity {
 
     private void validateNonExistGoal(Category category) {
         if (hasGoal(category)) {
-            log.info(String.format("멤버 (%s) 는 목표 (%s)을 이미 설정하였습니다", email, category));
-            throw new ConflictException("이미 설정한 목표입니다");
+            throw new ConflictException(String.format("멤버 (%s) 는 목표 (%s)을 이미 설정하였습니다", email, category), "이미 설정한 목표입니다");
         }
     }
 

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/Member.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/Member.java
@@ -2,10 +2,12 @@ package com.depromeet.domain.member;
 
 import com.depromeet.domain.common.Category;
 import com.depromeet.domain.BaseTimeEntity;
+import com.deprommet.exception.ConflictException;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 
 import javax.persistence.CascadeType;
@@ -20,6 +22,7 @@ import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -104,7 +107,8 @@ public class Member extends BaseTimeEntity {
 
     private void validateNonExistGoal(Category category) {
         if (hasGoal(category)) {
-            throw new IllegalArgumentException(String.format("멤버 (%s)는 목표 (%s)을 이미 설정하였습니다", id, category));
+            log.info(String.format("멤버 (%s) 는 목표 (%s)을 이미 설정하였습니다", email, category));
+            throw new ConflictException("이미 설정한 목표입니다");
         }
     }
 

--- a/miracle-domain/src/test/java/com/depromeet/domain/member/EmailTest.java
+++ b/miracle-domain/src/test/java/com/depromeet/domain/member/EmailTest.java
@@ -1,5 +1,6 @@
 package com.depromeet.domain.member;
 
+import com.deprommet.exception.ValidationException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,7 +29,7 @@ class EmailTest {
         // when & then
         assertThatThrownBy(() -> {
             Email.of(email);
-        }).isInstanceOf(IllegalArgumentException.class);
+        }).isInstanceOf(ValidationException.class);
     }
 
     @Test
@@ -39,7 +40,7 @@ class EmailTest {
         // when & then
         assertThatThrownBy(() -> {
             Email.of(email);
-        }).isInstanceOf(IllegalArgumentException.class);
+        }).isInstanceOf(ValidationException.class);
     }
 
     @Test
@@ -50,7 +51,7 @@ class EmailTest {
         // when & then
         assertThatThrownBy(() -> {
             Email.of(email);
-        }).isInstanceOf(IllegalArgumentException.class);
+        }).isInstanceOf(ValidationException.class);
     }
 
 }

--- a/miracle-exception/build.gradle
+++ b/miracle-exception/build.gradle
@@ -1,0 +1,2 @@
+bootJar { enabled = false }
+jar { enabled = true }

--- a/miracle-exception/src/main/java/com/deprommet/exception/ConflictException.java
+++ b/miracle-exception/src/main/java/com/deprommet/exception/ConflictException.java
@@ -1,9 +1,9 @@
 package com.deprommet.exception;
 
-public class ConflictException extends RuntimeException {
+public class ConflictException extends CustomException {
 
-    public ConflictException(String message) {
-        super(message);
+    public ConflictException(String message, String clientMessage) {
+        super(message, clientMessage);
     }
 
 }

--- a/miracle-exception/src/main/java/com/deprommet/exception/ConflictException.java
+++ b/miracle-exception/src/main/java/com/deprommet/exception/ConflictException.java
@@ -1,0 +1,9 @@
+package com.deprommet.exception;
+
+public class ConflictException extends RuntimeException {
+
+    public ConflictException(String message) {
+        super(message);
+    }
+
+}

--- a/miracle-exception/src/main/java/com/deprommet/exception/CustomException.java
+++ b/miracle-exception/src/main/java/com/deprommet/exception/CustomException.java
@@ -1,0 +1,15 @@
+package com.deprommet.exception;
+
+import lombok.Getter;
+
+@Getter
+abstract class CustomException extends RuntimeException {
+
+    private String clientMessage;
+
+    CustomException(String message, String clientMessage) {
+        super(message);
+        this.clientMessage = clientMessage;
+    }
+
+}

--- a/miracle-exception/src/main/java/com/deprommet/exception/InvalidSessionException.java
+++ b/miracle-exception/src/main/java/com/deprommet/exception/InvalidSessionException.java
@@ -1,9 +1,9 @@
 package com.deprommet.exception;
 
-public class InvalidSessionException extends RuntimeException {
+public class InvalidSessionException extends CustomException {
 
-    public InvalidSessionException(String message) {
-        super(message);
+    public InvalidSessionException(String message, String clientMessage) {
+        super(message, clientMessage);
     }
 
 }

--- a/miracle-exception/src/main/java/com/deprommet/exception/InvalidSessionException.java
+++ b/miracle-exception/src/main/java/com/deprommet/exception/InvalidSessionException.java
@@ -1,0 +1,9 @@
+package com.deprommet.exception;
+
+public class InvalidSessionException extends RuntimeException {
+
+    public InvalidSessionException(String message) {
+        super(message);
+    }
+
+}

--- a/miracle-exception/src/main/java/com/deprommet/exception/NotFoundException.java
+++ b/miracle-exception/src/main/java/com/deprommet/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package com.deprommet.exception;
+
+public class NotFoundException extends RuntimeException {
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/miracle-exception/src/main/java/com/deprommet/exception/NotFoundException.java
+++ b/miracle-exception/src/main/java/com/deprommet/exception/NotFoundException.java
@@ -1,9 +1,9 @@
 package com.deprommet.exception;
 
-public class NotFoundException extends RuntimeException {
+public class NotFoundException extends CustomException {
 
-    public NotFoundException(String message) {
-        super(message);
+    public NotFoundException(String message, String clientMessage) {
+        super(message, clientMessage);
     }
 
 }

--- a/miracle-exception/src/main/java/com/deprommet/exception/ValidationException.java
+++ b/miracle-exception/src/main/java/com/deprommet/exception/ValidationException.java
@@ -1,9 +1,9 @@
 package com.deprommet.exception;
 
-public class ValidationException extends RuntimeException {
+public class ValidationException extends CustomException {
 
-    public ValidationException(String message) {
-        super(message);
+    public ValidationException(String message, String clientMessage) {
+        super(message, clientMessage);
     }
 
 }

--- a/miracle-exception/src/main/java/com/deprommet/exception/ValidationException.java
+++ b/miracle-exception/src/main/java/com/deprommet/exception/ValidationException.java
@@ -1,0 +1,9 @@
+package com.deprommet.exception;
+
+public class ValidationException extends RuntimeException {
+
+    public ValidationException(String message) {
+        super(message);
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'miracle'
 include 'miracle-api'
 include 'miracle-domain'
+include 'miracle-exception'
 


### PR DESCRIPTION
**Exception Handler**
- 서버에서 처리한 메시지를 사용자에게 바로 보여주도록 메시지 설정. (i18n 다국어 적용 없이 진행.)
- Exception 발생시, code에 Exception의 종류가 리턴되고 (200 OK일시 "" 반환) (HttpStatus와 별도로 반환되는 code값입니다.)
- Exception 발생시, message에 해당 Exception의 메시지가 반환 (200 OK일시 "" 반환)

**현재 생성한 [Custom Exception Code - Http Status 종류] (차후 계속 추가됩니다..)** 
- NOT_FOUND_EXCEPTION -  404 (NotFound)  
- CONFLICT_EXCEPTION -  409 (Conflict)
- INVALID_SESSION_EXCEPTION -  401 (Unauthorized)
- VALIDATION_EXCEPTION - 400 (BadRequest)
- BAD_REQUEST_EXCEPTION - 400 (BadRequest)

**에러 발생 예시**
```
HTTP/1.1 409 
{
    "code": "CONFLICT_EXCEPTION",
    "message": "이미 가입한 멤버입니다",
    "data": null
}
```
```
HTTP/1.1 400
{
    "code": "VALIDATION_EXCEPTION",
    "message": "잘못된 이메일 형식입니다",
    "data": null
}
```

**200 OK  예시**
```
HTTP/1.1 200 
{
    "code": "",
    "message": "",
    "data": {
        "id": 1,
        "email": "ksh980212@gmail.com",
        "name": "강승호",
        "profileIcon": "RED",
        "goals": [
            "READING",
            "EXERCISE",
            "PROMISE"
        ]
    }
}
```