### PR TITLE
feat: 멤버 - 기상시간 필드를 Alarm과 별도로 멤버 필드에 추가 (요구사항 변경)

### DIFF
--- a/http/member.http
+++ b/http/member.http
@@ -11,7 +11,7 @@ Content-Type: application/json
         "EXERCISE",
         "PROMISE"
     ],
-    "wakeUpTime": "08:00"
+    "wakeUpTime": "06:00"
 }
 > {%
 client.global.set("AUTHORIZATION", response.body["data"])
@@ -29,7 +29,8 @@ Content-Type: application/json
 
 {
     "name": "호승강",
-    "profileIcon": "BLUE"
+    "profileIcon": "BLUE",
+    "wakeUpTime": "11:00"
 }
 
 ### 회원의 목표 변경 API

--- a/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmEventListener.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmEventListener.java
@@ -1,6 +1,7 @@
 package com.depromeet.controller.alarm;
 
 import com.depromeet.event.alarm.NewMemberRegisteredEvent;
+import com.depromeet.event.alarm.WakeUpTimeUpdatedEvent;
 import com.depromeet.service.alarm.AlarmService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -15,6 +16,11 @@ public class AlarmEventListener {
     @EventListener
     public void createDefaultWakeUpAlarm(NewMemberRegisteredEvent event) {
         alarmService.createDefaultWakeUpAlarmSchedule(event.getMemberId(), event.getWakeUpTime());
+    }
+
+    @EventListener
+    public void updateWakeUpAlarm(WakeUpTimeUpdatedEvent event) {
+        alarmService.updateDefaultWakeUpAlarmSchedule(event.getMemberId(), event.getWakeUpTime());
     }
 
 }

--- a/miracle-api/src/main/java/com/depromeet/event/alarm/WakeUpTimeUpdatedEvent.java
+++ b/miracle-api/src/main/java/com/depromeet/event/alarm/WakeUpTimeUpdatedEvent.java
@@ -1,0 +1,21 @@
+package com.depromeet.event.alarm;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class WakeUpTimeUpdatedEvent {
+
+    private final Long memberId;
+
+    private final LocalTime wakeUpTime;
+
+    public static WakeUpTimeUpdatedEvent of(Long memberId, LocalTime wakeUpTime) {
+        return new WakeUpTimeUpdatedEvent(memberId, wakeUpTime);
+    }
+
+}

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
@@ -30,6 +30,13 @@ public class AlarmService {
     }
 
     @Transactional
+    public void updateDefaultWakeUpAlarmSchedule(Long memberId, LocalTime wakeUpTime) {
+        List<AlarmSchedule> findAlarmSchedules = alarmScheduleRepository.findWakeUpAlarmSchedulesByMemberId(memberId);
+        alarmScheduleRepository.deleteAll(findAlarmSchedules);
+        createDefaultWakeUpAlarmSchedule(memberId, wakeUpTime);
+    }
+
+    @Transactional
     public AlarmScheduleInfoResponse createAlarmSchedule(CreateAlarmScheduleRequest request, Long memberId) {
         AlarmSchedule alarmSchedule = alarmScheduleRepository.save(request.toEntity(memberId));
         return AlarmScheduleInfoResponse.of(alarmSchedule);

--- a/miracle-api/src/main/java/com/depromeet/service/member/MemberService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/MemberService.java
@@ -3,6 +3,7 @@ package com.depromeet.service.member;
 import com.depromeet.domain.member.Member;
 import com.depromeet.domain.member.MemberRepository;
 import com.depromeet.event.alarm.NewMemberRegisteredEvent;
+import com.depromeet.event.alarm.WakeUpTimeUpdatedEvent;
 import com.depromeet.service.member.dto.request.SignUpMemberRequest;
 import com.depromeet.service.member.dto.request.UpdateMemberGoalsRequest;
 import com.depromeet.service.member.dto.request.UpdateMemberInfoRequest;
@@ -30,7 +31,8 @@ public class MemberService {
     @Transactional
     public MemberInfoResponse updateMemberInfo(UpdateMemberInfoRequest request, Long memberId) {
         Member member = MemberServiceUtils.findMemberById(memberRepository, memberId);
-        member.updateInfo(request.getName(), request.getProfileIcon());
+        member.updateInfo(request.getName(), request.getProfileIcon(), request.getWakeUpTime());
+        eventPublisher.publishEvent(WakeUpTimeUpdatedEvent.of(member.getId(), request.getWakeUpTime()));
         return MemberInfoResponse.of(member);
     }
 

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/request/SignUpMemberRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/request/SignUpMemberRequest.java
@@ -44,7 +44,7 @@ public class SignUpMemberRequest {
     }
 
     public Member toEntity() {
-        Member member = Member.newInstance(email, name, profileIcon);
+        Member member = Member.newInstance(email, name, profileIcon, wakeUpTime);
         member.addMemberGoals(toMemberGoals());
         return member;
     }

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberInfoRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberInfoRequest.java
@@ -5,14 +5,18 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor
 public class UpdateMemberInfoRequest {
 
+    @NotBlank(message = "닉네임을 입력해주세요")
     private String name;
 
+    @NotNull(message = "프로필 아이콘을 선택해주세요.")
     private ProfileIcon profileIcon;
 
     private LocalTime wakeUpTime;

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberInfoRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/request/UpdateMemberInfoRequest.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalTime;
+
 @Getter
 @NoArgsConstructor
 public class UpdateMemberInfoRequest {
@@ -13,10 +15,13 @@ public class UpdateMemberInfoRequest {
 
     private ProfileIcon profileIcon;
 
+    private LocalTime wakeUpTime;
+
     @Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
-    public UpdateMemberInfoRequest(String name, ProfileIcon profileIcon) {
+    public UpdateMemberInfoRequest(String name, ProfileIcon profileIcon, LocalTime wakeUpTime) {
         this.name = name;
         this.profileIcon = profileIcon;
+        this.wakeUpTime = wakeUpTime;
     }
 
 }

--- a/miracle-api/src/main/java/com/depromeet/service/member/dto/response/MemberInfoResponse.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/dto/response/MemberInfoResponse.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,10 +24,12 @@ public class MemberInfoResponse {
 
     private final ProfileIcon profileIcon;
 
+    private final LocalTime wakeUpTime;
+
     private final List<Category> goals;
 
     public static MemberInfoResponse of(Member member) {
-        return new MemberInfoResponse(member.getId(), member.getEmail(), member.getName(), member.getProfileIcon(), convertMemberGoalsToCategories(member));
+        return new MemberInfoResponse(member.getId(), member.getEmail(), member.getName(), member.getProfileIcon(), member.getWakeUpTime(), convertMemberGoalsToCategories(member));
     }
 
     private static List<Category> convertMemberGoalsToCategories(Member member) {

--- a/miracle-api/src/main/resources/application.yml
+++ b/miracle-api/src/main/resources/application.yml
@@ -23,6 +23,9 @@ spring:
             jdbc-url: jdbc:h2:mem:mimo;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
             username: sa
             password: sa
+    jpa:
+        hibernate:
+            ddl-auto: update
 
 ---
 

--- a/miracle-api/src/main/resources/db/migration/V2__add_wakeup_field.sql
+++ b/miracle-api/src/main/resources/db/migration/V2__add_wakeup_field.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `MEMBER` ADD `wake_up_time` time DEFAULT NULL;

--- a/miracle-api/src/test/java/com/depromeet/service/member/MemberServiceTest.java
+++ b/miracle-api/src/test/java/com/depromeet/service/member/MemberServiceTest.java
@@ -246,7 +246,7 @@ class MemberServiceTest {
         // then
         List<AlarmSchedule> alarmSchedules = alarmScheduleRepository.findAll();
         assertThat(alarmSchedules).hasSize(1);
-        assertThat(alarmSchedules.get(0)).isNotEqualTo(alarmSchedule.getId());
+        assertThat(alarmSchedules.get(0).getId()).isNotEqualTo(alarmSchedule.getId());
         assertThat(alarmSchedules.get(0).getType()).isEqualTo(AlarmType.WAKE_UP);
 
         List<Alarm> alarms = alarmRepository.findAll();

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/repository/AlarmScheduleRepositoryCustom.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/repository/AlarmScheduleRepositoryCustom.java
@@ -10,4 +10,6 @@ public interface AlarmScheduleRepositoryCustom {
 
     AlarmSchedule findAlarmScheduleByIdAndMemberId(Long id, Long memberId);
 
+    List<AlarmSchedule> findWakeUpAlarmSchedulesByMemberId(Long memberId);
+
 }

--- a/miracle-domain/src/main/java/com/depromeet/domain/alarm/repository/AlarmScheduleRepositoryCustomImpl.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/alarm/repository/AlarmScheduleRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.depromeet.domain.alarm.repository;
 
 import com.depromeet.domain.alarm.AlarmSchedule;
+import com.depromeet.domain.alarm.AlarmType;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -31,6 +32,16 @@ public class AlarmScheduleRepositoryCustomImpl implements AlarmScheduleRepositor
                 alarmSchedule.id.eq(id),
                 alarmSchedule.memberId.eq(memberId)
             ).fetchOne();
+    }
+
+    @Override
+    public List<AlarmSchedule> findWakeUpAlarmSchedulesByMemberId(Long memberId) {
+        return queryFactory.selectFrom(alarmSchedule).distinct()
+            .leftJoin(alarmSchedule.alarms, alarm).fetchJoin()
+            .where(
+                alarmSchedule.memberId.eq(memberId),
+                alarmSchedule.type.eq(AlarmType.WAKE_UP)
+            ).fetch();
     }
 
 }

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/Member.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/Member.java
@@ -18,6 +18,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,20 +50,24 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private MemberType type;
 
+    private LocalTime wakeUpTime;
+
     @Builder
-    public Member(String email, String name, ProfileIcon profileIcon) {
+    public Member(String email, String name, ProfileIcon profileIcon, LocalTime wakeUpTime) {
         this.email = Email.of(email);
         this.name = name;
         this.profileIcon = profileIcon;
+        this.wakeUpTime = wakeUpTime;
         this.provider = AuthProvider.GOOGLE;
         this.type = MemberType.FREE;
     }
 
-    public static Member newInstance(String email, String name, ProfileIcon profileIcon) {
+    public static Member newInstance(String email, String name, ProfileIcon profileIcon, LocalTime wakeUpTime) {
         return Member.builder()
             .email(email)
             .name(name)
             .profileIcon(profileIcon)
+            .wakeUpTime(wakeUpTime)
             .build();
     }
 
@@ -70,12 +75,15 @@ public class Member extends BaseTimeEntity {
         return email.getEmail();
     }
 
-    public void updateInfo(String name, ProfileIcon profileIcon) {
+    public void updateInfo(String name, ProfileIcon profileIcon, LocalTime wakeUpTime) {
         if (StringUtils.hasText(name)) {
             this.name = name;
         }
         if (profileIcon != null) {
             this.profileIcon = profileIcon;
+        }
+        if (wakeUpTime != null) {
+            this.wakeUpTime = wakeUpTime;
         }
     }
 

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/Member.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/Member.java
@@ -6,7 +6,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.StringUtils;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -76,15 +75,9 @@ public class Member extends BaseTimeEntity {
     }
 
     public void updateInfo(String name, ProfileIcon profileIcon, LocalTime wakeUpTime) {
-        if (StringUtils.hasText(name)) {
-            this.name = name;
-        }
-        if (profileIcon != null) {
-            this.profileIcon = profileIcon;
-        }
-        if (wakeUpTime != null) {
-            this.wakeUpTime = wakeUpTime;
-        }
+        this.name = name;
+        this.profileIcon = profileIcon;
+        this.wakeUpTime = wakeUpTime;
     }
 
     public void updateMemberGoals(List<MemberGoal> memberGoals) {


### PR DESCRIPTION
- Alarm Domain 은 확장을 할 시, 사용할 것 같습니다. (차후, 확장시 Member에서 필드 삭제)

- PUT member로 멤버의 기상 시간 정보를 변경하면
1. 기존에 존재하는 기상을 위한 알람 스케쥴이 삭제되고,
2. 변경된 기상 시간으로 새로운 기상 알람 스케쥴이 생성되는 로직.