### PR TITLE
각 도메인에서 Category enum class 를 동일하게 사용하도록 수정, 인증 코멘트 조회 API 추가

### DIFF
--- a/http/schedule.http
+++ b/http/schedule.http
@@ -6,7 +6,7 @@ Content-Type: application/json
 {
     "startTime": "2020-08-06T16:30:00",
     "endTime": "2020-08-06T17:00:00",
-    "category": "운동",
+    "category": "EXERCISE",
     "description": "운동하기",
     "loopType": "NONE"
 }
@@ -29,7 +29,7 @@ Content-Type: application/json
 {
   "startTime": "2020-08-09T16:30:00",
   "endTime": "2020-08-09T17:00:00",
-  "category": "명상",
+  "category": "MEDITATION",
   "description": "명상하기",
   "loopType": "DAY"
 }

--- a/http/schedule.http
+++ b/http/schedule.http
@@ -44,3 +44,9 @@ Authorization: Bearer {{AUTHORIZATION}}
 Content-Type: application/json
 
 ###
+
+GET {{host}}/api/v1/schedule/{{SCHEDULE_ID}}/category/comment
+Authorization: Bearer {{AUTHORIZATION}}
+Content-Type: application/json
+
+###

--- a/miracle-api/src/main/java/com/depromeet/controller/schedule/ScheduleController.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/schedule/ScheduleController.java
@@ -3,6 +3,7 @@ package com.depromeet.controller.schedule;
 import com.depromeet.ApiResponse;
 import com.depromeet.config.resolver.LoginMember;
 import com.depromeet.config.session.MemberSession;
+import com.depromeet.service.schedule.dto.GetCategoryComment;
 import com.depromeet.service.schedule.ScheduleService;
 import com.depromeet.service.schedule.dto.*;
 import org.springframework.http.MediaType;
@@ -69,5 +70,10 @@ public class ScheduleController {
     public ApiResponse<String> deleteSchedule(@LoginMember MemberSession session, @PathVariable long scheduleId) {
         scheduleService.deleteSchedule(session.getMemberId(), scheduleId);
         return ApiResponse.SUCCESS;
+    }
+
+    @GetMapping(value = "/api/v1/schedule/{scheduleId}/category/comment", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<GetCategoryComment> getCategoryComment(@LoginMember MemberSession session, @PathVariable long scheduleId) {
+        return ApiResponse.of(scheduleService.getCategoryComment(session.getMemberId(), scheduleId));
     }
 }

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
@@ -83,4 +83,20 @@ public class ScheduleService {
 
         repository.delete(schedule);
     }
+
+    /**
+     * 스케쥴 인증을 위해 카테고리별 인증 코멘트를 조회한다.
+     * @param memberId
+     * @param scheduleId
+     * @return
+     */
+    public GetCategoryComment getCategoryComment(Long memberId, long scheduleId) {
+        Schedule schedule = repository.findById(scheduleId).orElseThrow(() -> new NoSuchElementException(String.format("스케쥴 (%d)은 존재하지 않습니다", scheduleId)));
+
+        if (schedule.getMemberId() != memberId) {
+            throw new IllegalAccessException(String.format("스케쥴 (%d)에 접근할 수 없습니다.", scheduleId), "스케쥴에 접근할 수 없습니다.");
+        }
+
+        return new GetCategoryComment(schedule.getCategory().retrieveRecordComment());
+    }
 }

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/ScheduleService.java
@@ -56,9 +56,9 @@ public class ScheduleService {
     /**
      * 데이터 베이스의 스케쥴을 수정한다.
      *
-     * @param memberId 가입 멤버 ID
+     * @param memberId   가입 멤버 ID
      * @param scheduleId 수정하고자 하는 스케쥴 ID
-     * @param request  수정하고자 하는 스케쥴 정보
+     * @param request    수정하고자 하는 스케쥴 정보
      * @return
      */
     @Transactional
@@ -71,9 +71,10 @@ public class ScheduleService {
     /**
      * 데이터 베이스의 스케쥴을 삭제한다.
      *
-     * @param memberId 가입 멤버 ID
-     * @param scheduleId  삭제하고자 하는 스케쥴 ID
+     * @param memberId   가입 멤버 ID
+     * @param scheduleId 삭제하고자 하는 스케쥴 ID
      */
+    @Transactional
     public void deleteSchedule(long memberId, long scheduleId) {
         Schedule schedule = repository.findById(scheduleId).orElseThrow(() -> new NoSuchElementException(String.format("스케쥴 (%d)은 존재하지 않습니다", scheduleId)));
 
@@ -86,10 +87,12 @@ public class ScheduleService {
 
     /**
      * 스케쥴 인증을 위해 카테고리별 인증 코멘트를 조회한다.
-     * @param memberId
-     * @param scheduleId
-     * @return
+     *
+     * @param memberId   가입 멤버 ID
+     * @param scheduleId 인증 코멘트가 필요한 스케쥴 ID
+     * @return 인증 화면에 노출될 코멘트
      */
+    @Transactional(readOnly = true)
     public GetCategoryComment getCategoryComment(Long memberId, long scheduleId) {
         Schedule schedule = repository.findById(scheduleId).orElseThrow(() -> new NoSuchElementException(String.format("스케쥴 (%d)은 존재하지 않습니다", scheduleId)));
 

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/CreateScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/CreateScheduleRequest.java
@@ -1,5 +1,6 @@
 package com.depromeet.service.schedule.dto;
 
+import com.depromeet.domain.common.Category;
 import com.depromeet.domain.schedule.LoopType;
 import com.depromeet.domain.schedule.Schedule;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -24,7 +25,7 @@ public class CreateScheduleRequest {
     private LocalDateTime endTime;
 
     @NotBlank(message = "카테고리를 선택해주세요")
-    private String category;
+    private Category category;
 
     @NotBlank(message = "설명을 입력해주세요")
     @Length(max = 11, message = "11자 이하로 입력해주세요")
@@ -38,7 +39,7 @@ public class CreateScheduleRequest {
         // needed by jackson
     }
 
-    public CreateScheduleRequest(LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
+    public CreateScheduleRequest(LocalDateTime startTime, LocalDateTime endTime, Category category, String description, LoopType loopType) {
         this.startTime = startTime;
         this.endTime = endTime;
         this.category = category;
@@ -58,7 +59,7 @@ public class CreateScheduleRequest {
         return endTime;
     }
 
-    public String getCategory() {
+    public Category getCategory() {
         return category;
     }
 

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/GetCategoryComment.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/GetCategoryComment.java
@@ -1,0 +1,13 @@
+package com.depromeet.service.schedule.dto;
+
+public class GetCategoryComment {
+    private String comment;
+
+    public GetCategoryComment(String comment) {
+        this.comment = comment;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+}

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/GetScheduleResponse.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/GetScheduleResponse.java
@@ -1,5 +1,6 @@
 package com.depromeet.service.schedule.dto;
 
+import com.depromeet.domain.common.Category;
 import com.depromeet.domain.schedule.LoopType;
 import com.depromeet.domain.schedule.Schedule;
 import io.swagger.annotations.ApiModel;
@@ -16,12 +17,12 @@ public class GetScheduleResponse {
     private int dayOfWeek;
     private LocalTime startTime;
     private LocalTime endTime;
-    private String category;
+    private Category category;
     private String description;
     @ApiModelProperty
     private LoopType loopType;
 
-    public GetScheduleResponse(long id, int year, int month, int day, int dayOfWeek, LocalTime startTime, LocalTime endTime, String category, String description, LoopType loopType) {
+    public GetScheduleResponse(long id, int year, int month, int day, int dayOfWeek, LocalTime startTime, LocalTime endTime, Category category, String description, LoopType loopType) {
         this.id = id;
         this.year = year;
         this.month = month;
@@ -66,7 +67,7 @@ public class GetScheduleResponse {
         return endTime;
     }
 
-    public String getCategory() {
+    public Category getCategory() {
         return category;
     }
 

--- a/miracle-api/src/main/java/com/depromeet/service/schedule/dto/UpdateScheduleRequest.java
+++ b/miracle-api/src/main/java/com/depromeet/service/schedule/dto/UpdateScheduleRequest.java
@@ -1,5 +1,6 @@
 package com.depromeet.service.schedule.dto;
 
+import com.depromeet.domain.common.Category;
 import com.depromeet.domain.schedule.LoopType;
 import com.depromeet.domain.schedule.Schedule;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -22,7 +23,7 @@ public class UpdateScheduleRequest {
     private LocalDateTime endTime;
 
     @NotBlank(message = "카테고리를 선택해주세요")
-    private String category;
+    private Category category;
 
     @NotBlank(message = "설명을 입력해주세요")
     @Length(max = 11, message = "11자 이하로 입력해주세요")
@@ -36,7 +37,7 @@ public class UpdateScheduleRequest {
         // needed by jackson
     }
 
-    public UpdateScheduleRequest(LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
+    public UpdateScheduleRequest(LocalDateTime startTime, LocalDateTime endTime, Category category, String description, LoopType loopType) {
         this.startTime = startTime;
         this.endTime = endTime;
         this.category = category;
@@ -56,7 +57,7 @@ public class UpdateScheduleRequest {
         return endTime;
     }
 
-    public String getCategory() {
+    public Category getCategory() {
         return category;
     }
 

--- a/miracle-domain/src/main/java/com/depromeet/domain/common/Category.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/common/Category.java
@@ -1,10 +1,78 @@
 package com.depromeet.domain.common;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * 스케쥴 및 목표에 사용되는 카테고리
  */
 public enum Category {
+    EXERCISE {
+        private final List<String> comments = Arrays.asList("인상에 남는 구절은 무엇인가요?", "오늘 읽은 책에 대한 나의 생각을 적어주세요.");
 
-    EXERCISE, MEDITATION, READING, PROMISE, DIARY, PLAN
+        @Override
+        public String retrieveRecordComment() {
+            Collections.shuffle(comments);
+            return comments.get(0);
+        }
+    },
+    MEDITATION {
+        private final List<String> comments = Arrays.asList("오늘 하늘은 어땠나요?", "내 몸에서 가장 마음에 드는 곳은 어디인가요?");
 
+        @Override
+        public String retrieveRecordComment() {
+            Collections.shuffle(comments);
+            return comments.get(0);
+        }
+    },
+    READING {
+        private final List<String> comments = Arrays.asList("오늘은 어떤 생각을 하셨나요?", "어떤 꿈을 자주 꾸나요?");
+
+        @Override
+        public String retrieveRecordComment() {
+            Collections.shuffle(comments);
+            return comments.get(0);
+        }
+    },
+    PROMISE {
+        private final List<String> comments = Arrays.asList("5년 뒤 나의 모습은 어떨까요?", "올해 이루고 싶은 일은 무엇인가요?");
+
+        @Override
+        public String retrieveRecordComment() {
+            Collections.shuffle(comments);
+            return comments.get(0);
+        }
+    },
+    DIARY {
+        private final List<String> comments = Arrays.asList("어제 가장 행복했던 순간은 무엇이었나요?", "오늘 일기에 등장한 사람은 누구인가요?");
+
+        @Override
+        public String retrieveRecordComment() {
+            Collections.shuffle(comments);
+            return comments.get(0);
+        }
+    },
+    PLAN {
+        private final List<String> comments = Arrays.asList("오늘 하루 꼭 이루고 싶은 것은 무엇인가요?", "오늘 계획을 성공한다면, 자신에게 주고 싶은 선물은 무엇인가요?");
+
+        @Override
+        public String retrieveRecordComment() {
+            Collections.shuffle(comments);
+            return comments.get(0);
+        }
+    },
+    ETC {
+        private final List<String> comments = Arrays.asList("TBD", "TBD");
+
+        @Override
+        public String retrieveRecordComment() {
+            Collections.shuffle(comments);
+            return comments.get(0);
+        }
+    };
+
+    public String retrieveRecordComment() {
+        return "";
+    }
 }

--- a/miracle-domain/src/main/java/com/depromeet/domain/common/Category.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/common/Category.java
@@ -8,71 +8,22 @@ import java.util.List;
  * 스케쥴 및 목표에 사용되는 카테고리
  */
 public enum Category {
-    EXERCISE {
-        private final List<String> comments = Arrays.asList("인상에 남는 구절은 무엇인가요?", "오늘 읽은 책에 대한 나의 생각을 적어주세요.");
+    EXERCISE(Arrays.asList("인상에 남는 구절은 무엇인가요?", "오늘 읽은 책에 대한 나의 생각을 적어주세요.")),
+    MEDITATION(Arrays.asList("오늘 하늘은 어땠나요?", "내 몸에서 가장 마음에 드는 곳은 어디인가요?")),
+    READING(Arrays.asList("오늘은 어떤 생각을 하셨나요?", "어떤 꿈을 자주 꾸나요?")),
+    PROMISE(Arrays.asList("5년 뒤 나의 모습은 어떨까요?", "올해 이루고 싶은 일은 무엇인가요?")),
+    DIARY(Arrays.asList("어제 가장 행복했던 순간은 무엇이었나요?", "오늘 일기에 등장한 사람은 누구인가요?")),
+    PLAN(Arrays.asList("오늘 하루 꼭 이루고 싶은 것은 무엇인가요?", "오늘 계획을 성공한다면, 자신에게 주고 싶은 선물은 무엇인가요?")),
+    ETC(Arrays.asList("TBD", "TBD"));
 
-        @Override
-        public String retrieveRecordComment() {
-            Collections.shuffle(comments);
-            return comments.get(0);
-        }
-    },
-    MEDITATION {
-        private final List<String> comments = Arrays.asList("오늘 하늘은 어땠나요?", "내 몸에서 가장 마음에 드는 곳은 어디인가요?");
+    private final List<String> comments;
 
-        @Override
-        public String retrieveRecordComment() {
-            Collections.shuffle(comments);
-            return comments.get(0);
-        }
-    },
-    READING {
-        private final List<String> comments = Arrays.asList("오늘은 어떤 생각을 하셨나요?", "어떤 꿈을 자주 꾸나요?");
-
-        @Override
-        public String retrieveRecordComment() {
-            Collections.shuffle(comments);
-            return comments.get(0);
-        }
-    },
-    PROMISE {
-        private final List<String> comments = Arrays.asList("5년 뒤 나의 모습은 어떨까요?", "올해 이루고 싶은 일은 무엇인가요?");
-
-        @Override
-        public String retrieveRecordComment() {
-            Collections.shuffle(comments);
-            return comments.get(0);
-        }
-    },
-    DIARY {
-        private final List<String> comments = Arrays.asList("어제 가장 행복했던 순간은 무엇이었나요?", "오늘 일기에 등장한 사람은 누구인가요?");
-
-        @Override
-        public String retrieveRecordComment() {
-            Collections.shuffle(comments);
-            return comments.get(0);
-        }
-    },
-    PLAN {
-        private final List<String> comments = Arrays.asList("오늘 하루 꼭 이루고 싶은 것은 무엇인가요?", "오늘 계획을 성공한다면, 자신에게 주고 싶은 선물은 무엇인가요?");
-
-        @Override
-        public String retrieveRecordComment() {
-            Collections.shuffle(comments);
-            return comments.get(0);
-        }
-    },
-    ETC {
-        private final List<String> comments = Arrays.asList("TBD", "TBD");
-
-        @Override
-        public String retrieveRecordComment() {
-            Collections.shuffle(comments);
-            return comments.get(0);
-        }
-    };
+    Category(List<String> comments) {
+        this.comments = comments;
+    }
 
     public String retrieveRecordComment() {
-        return "";
+        Collections.shuffle(comments);
+        return comments.get(0);
     }
 }

--- a/miracle-domain/src/main/java/com/depromeet/domain/schedule/Schedule.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/schedule/Schedule.java
@@ -3,6 +3,7 @@ package com.depromeet.domain.schedule;
 import com.depromeet.domain.BaseTimeEntity;
 import com.deprommet.exception.IllegalAccessException;
 import com.deprommet.exception.ValidationException;
+import com.depromeet.domain.common.Category;
 
 import javax.persistence.*;
 import java.time.DayOfWeek;
@@ -32,7 +33,8 @@ public class Schedule extends BaseTimeEntity {
 
     private LocalTime endTime;
 
-    private String category;
+    @Enumerated(EnumType.STRING)
+    private Category category;
 
     private String description;
 
@@ -43,7 +45,7 @@ public class Schedule extends BaseTimeEntity {
         //needed by hibernate
     }
 
-    public Schedule(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
+    public Schedule(long memberId, LocalDateTime startTime, LocalDateTime endTime, Category category, String description, LoopType loopType) {
         validateTime(startTime, endTime);
         this.memberId = memberId;
         this.year = startTime.getYear();
@@ -57,7 +59,7 @@ public class Schedule extends BaseTimeEntity {
         this.loopType = loopType;
     }
 
-    public static Schedule of(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
+    public static Schedule of(long memberId, LocalDateTime startTime, LocalDateTime endTime, Category category, String description, LoopType loopType) {
         return new Schedule(memberId, startTime, endTime, category, description, loopType);
     }
 
@@ -70,7 +72,7 @@ public class Schedule extends BaseTimeEntity {
         }
     }
 
-    public void update(long memberId, LocalDateTime startTime, LocalDateTime endTime, String category, String description, LoopType loopType) {
+    public void update(long memberId, LocalDateTime startTime, LocalDateTime endTime, Category category, String description, LoopType loopType) {
         if (this.memberId != memberId) {
             throw new IllegalAccessException(String.format("타인의 스케쥴 (%d)은 수정할 수 없습니다", this.id), "타인의 스케쥴은 수정할 수 없습니다");
         }
@@ -119,7 +121,7 @@ public class Schedule extends BaseTimeEntity {
         return endTime;
     }
 
-    public String getCategory() {
+    public Category getCategory() {
         return category;
     }
 


### PR DESCRIPTION
* Category enum class
  * 독서, 운동, 명상, 다짐, 일기, 계획, 기타
    * '기타' 카테고리는 미라클 선택화면에서 노출되지 않습니다. 이건 클라 스펙으로 하는게 좋을 것 같습니다.
  * 각 카테고리당 인증 화면에서 노출해주는 코멘트 2개가 있고, 인증 시에 무작위 1개 코멘트가 노출됩니다.
  * 상태와 행위를 한 곳에서 관리하기 위해 enum class 를 좀 더 확장했습니다.
* 카테고리를 쓰는 영역은 MemberGoals, Schedule, Record 도메인이고, 모두 동일하게 Category class 를 사용하도록 합니다.
  * 해당 MR 에서는 Schedule 도메인에서 Category를 사용하도록 수정되었습니다.