### PR TITLE
feat: 회원 탈퇴 API 개발 및 백업용 멤버 도메인 설계

### DIFF
--- a/http/member.http
+++ b/http/member.http
@@ -45,4 +45,9 @@ Content-Type: application/json
     ]
 }
 
+### 회원 탈퇴 API
+DELETE {{host}}/api/v1/member
+Authorization: Bearer {{AUTHORIZATION}}
+
 ###
+

--- a/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmEventListener.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/alarm/AlarmEventListener.java
@@ -2,6 +2,7 @@ package com.depromeet.controller.alarm;
 
 import com.depromeet.event.alarm.NewMemberRegisteredEvent;
 import com.depromeet.event.alarm.WakeUpTimeUpdatedEvent;
+import com.depromeet.event.memer.MemberDeletedEvent;
 import com.depromeet.service.alarm.AlarmService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -21,6 +22,11 @@ public class AlarmEventListener {
     @EventListener
     public void updateWakeUpAlarm(WakeUpTimeUpdatedEvent event) {
         alarmService.updateDefaultWakeUpAlarmSchedule(event.getMemberId(), event.getWakeUpTime());
+    }
+
+    @EventListener
+    public void deleteWakeUpAlarm(MemberDeletedEvent event) {
+        alarmService.deleteAlarmScheduleByMemberId(event.getMemberId());
     }
 
 }

--- a/miracle-api/src/main/java/com/depromeet/controller/member/MemberController.java
+++ b/miracle-api/src/main/java/com/depromeet/controller/member/MemberController.java
@@ -62,7 +62,7 @@ public class MemberController {
     }
 
     /**
-     * 회원정보를 삭제하는 API (테스트용도)
+     * 회원 탈퇴 API
      */
     @DeleteMapping("/api/v1/member")
     public ApiResponse<String> deleteMemberInfo(@LoginMember MemberSession memberSession) {

--- a/miracle-api/src/main/java/com/depromeet/event/memer/MemberDeletedEvent.java
+++ b/miracle-api/src/main/java/com/depromeet/event/memer/MemberDeletedEvent.java
@@ -1,0 +1,19 @@
+package com.depromeet.event.memer;
+
+public class MemberDeletedEvent {
+
+    private final Long memberId;
+
+    private MemberDeletedEvent(Long memberId) {
+        this.memberId = memberId;
+    }
+
+    public static MemberDeletedEvent of(Long memberId) {
+        return new MemberDeletedEvent(memberId);
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+    
+}

--- a/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/alarm/AlarmService.java
@@ -69,4 +69,10 @@ public class AlarmService {
         alarmScheduleRepository.delete(alarmSchedule);
     }
 
+    @Transactional
+    public void deleteAlarmScheduleByMemberId(Long memberId) {
+        List<AlarmSchedule> alarmSchedules = alarmScheduleRepository.findAlarmSchedulesByMemberId(memberId);
+        alarmScheduleRepository.deleteAll(alarmSchedules);
+    }
+
 }

--- a/miracle-api/src/main/java/com/depromeet/service/member/MemberService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/MemberService.java
@@ -6,6 +6,7 @@ import com.depromeet.domain.member.deleted.DeletedMember;
 import com.depromeet.domain.member.deleted.DeletedMemberRepository;
 import com.depromeet.event.alarm.NewMemberRegisteredEvent;
 import com.depromeet.event.alarm.WakeUpTimeUpdatedEvent;
+import com.depromeet.event.memer.MemberDeletedEvent;
 import com.depromeet.service.member.dto.request.SignUpMemberRequest;
 import com.depromeet.service.member.dto.request.UpdateMemberGoalsRequest;
 import com.depromeet.service.member.dto.request.UpdateMemberInfoRequest;
@@ -57,6 +58,7 @@ public class MemberService {
         Member member = MemberServiceUtils.findMemberById(memberRepository, memberId);
         memberRepository.delete(member);
         deletedMemberRepository.save(DeletedMember.of(member));
+        eventPublisher.publishEvent(MemberDeletedEvent.of(member.getId()));
     }
 
 }

--- a/miracle-api/src/main/java/com/depromeet/service/member/MemberService.java
+++ b/miracle-api/src/main/java/com/depromeet/service/member/MemberService.java
@@ -2,6 +2,8 @@ package com.depromeet.service.member;
 
 import com.depromeet.domain.member.Member;
 import com.depromeet.domain.member.MemberRepository;
+import com.depromeet.domain.member.deleted.DeletedMember;
+import com.depromeet.domain.member.deleted.DeletedMemberRepository;
 import com.depromeet.event.alarm.NewMemberRegisteredEvent;
 import com.depromeet.event.alarm.WakeUpTimeUpdatedEvent;
 import com.depromeet.service.member.dto.request.SignUpMemberRequest;
@@ -19,6 +21,7 @@ public class MemberService {
 
     private final ApplicationEventPublisher eventPublisher;
     private final MemberRepository memberRepository;
+    private final DeletedMemberRepository deletedMemberRepository;
 
     @Transactional
     public Long signUpMember(SignUpMemberRequest request) {
@@ -53,6 +56,7 @@ public class MemberService {
     public void deleteMemberInfo(Long memberId) {
         Member member = MemberServiceUtils.findMemberById(memberRepository, memberId);
         memberRepository.delete(member);
+        deletedMemberRepository.save(DeletedMember.of(member));
     }
 
 }

--- a/miracle-api/src/test/java/com/depromeet/service/alarm/AlarmServiceTest.java
+++ b/miracle-api/src/test/java/com/depromeet/service/alarm/AlarmServiceTest.java
@@ -249,6 +249,43 @@ class AlarmServiceTest extends MemberSetup {
         assertThat(alarms).isEmpty();
     }
 
+    @Test
+    void 특정멤버의_알람_스케쥴을_모두_삭제한다() {
+        // given
+        AlarmSchedule alarmSchedule = AlarmScheduleCreator.createAlarmSchedule(memberId, AlarmType.WAKE_UP, "description");
+        alarmSchedule.addAlarms(Collections.singletonList(
+            AlarmCreator.createAlarm(DayOfTheWeek.MON, LocalTime.of(8, 0))
+        ));
+        alarmScheduleRepository.save(alarmSchedule);
+
+        // when
+        alarmService.deleteAlarmScheduleByMemberId(memberId);
+
+        // then
+        List<AlarmSchedule> alarmSchedules = alarmScheduleRepository.findAll();
+        assertThat(alarmSchedules).isEmpty();
+
+        List<Alarm> alarms = alarmRepository.findAll();
+        assertThat(alarms).isEmpty();
+    }
+
+    @Test
+    void 특정멤버의_알람_스케쥴의_알람_리스트도_모두_삭제한다() {
+        // given
+        alarmScheduleRepository.saveAll(Arrays.asList(
+            AlarmScheduleCreator.createAlarmSchedule(999L, AlarmType.WAKE_UP, "다른 멤버의 알림스케쥴"),
+            AlarmScheduleCreator.createAlarmSchedule(memberId, AlarmType.WAKE_UP, "첫 번째 알림스케쥴"),
+            AlarmScheduleCreator.createAlarmSchedule(memberId, AlarmType.WAKE_UP, "두 번째 알림스케쥴")));
+
+        // when
+        alarmService.deleteAlarmScheduleByMemberId(memberId);
+
+        // then
+        List<AlarmSchedule> alarmSchedules = alarmScheduleRepository.findAll();
+        assertThat(alarmSchedules).hasSize(1);
+        assertThat(alarmSchedules.get(0).getMemberId()).isEqualTo(999L);
+    }
+
     private void assertAlarmSchedule(AlarmSchedule alarmSchedule, String description, AlarmType type) {
         assertAll(
             () -> assertThat(alarmSchedule.getDescription()).isEqualTo(description),

--- a/miracle-api/src/test/java/com/depromeet/service/member/MemberServiceTest.java
+++ b/miracle-api/src/test/java/com/depromeet/service/member/MemberServiceTest.java
@@ -31,6 +31,9 @@ import com.deprommet.exception.NotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -38,6 +41,7 @@ import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -299,8 +303,9 @@ class MemberServiceTest {
         assertThat(memberGoals).isEmpty();
     }
 
-    @Test
-    void 내정보를_불러온다() {
+    @ParameterizedTest
+    @MethodSource(value = "source_load_my_info_ShouldSuccess")
+    void 내정보를_불러온다(Member member) {
         // given
         memberRepository.save(member);
 
@@ -309,6 +314,13 @@ class MemberServiceTest {
 
         // then
         assertMemberInfoResponse(response, member.getEmail(), member.getName(), member.getProfileIcon());
+    }
+
+    static Stream<Arguments> source_load_my_info_ShouldSuccess() {
+        return Stream.of(
+            Arguments.of(MemberCreator.create("will.seungho@gmail.com", "강승호", ProfileIcon.BLUE)),
+            Arguments.of(MemberCreator.create("ksh980212@gmail.com", "호승강", ProfileIcon.RED))
+        );
     }
 
     @Test

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/deleted/DeletedMember.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/deleted/DeletedMember.java
@@ -1,0 +1,105 @@
+package com.depromeet.domain.member.deleted;
+
+import com.depromeet.domain.BaseTimeEntity;
+import com.depromeet.domain.member.AuthProvider;
+import com.depromeet.domain.member.Email;
+import com.depromeet.domain.member.Member;
+import com.depromeet.domain.member.MemberGoal;
+import com.depromeet.domain.member.MemberType;
+import com.depromeet.domain.member.ProfileIcon;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 회원 탈퇴한 멤버 정보를 특정 기간동안 보관하는 도메인 (백업 용도)
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class DeletedMember extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long backupId; // 삭제되기 전의 id
+
+    @Embedded
+    private Email email;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ProfileIcon profileIcon;
+
+    @OneToMany(mappedBy = "deletedMember", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DeletedMemberGoal> deletedMemberGoals = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    private AuthProvider provider;
+
+    @Enumerated(EnumType.STRING)
+    private MemberType type;
+
+    private LocalTime wakeUpTime;
+
+    public String getEmail() {
+        return this.email.getEmail();
+    }
+
+    @Builder
+    public DeletedMember(Long backupId, String email, String name, ProfileIcon profileIcon, AuthProvider provider, MemberType type, LocalTime wakeUpTime) {
+        this.backupId = backupId;
+        this.email = Email.of(email);
+        this.name = name;
+        this.profileIcon = profileIcon;
+        this.provider = provider;
+        this.type = type;
+        this.wakeUpTime = wakeUpTime;
+    }
+
+    public static DeletedMember of(Member member) {
+        DeletedMember deletedMember = DeletedMember.builder()
+            .backupId(member.getId())
+            .email(member.getEmail())
+            .name(member.getName())
+            .profileIcon(member.getProfileIcon())
+            .provider(member.getProvider())
+            .type(member.getType())
+            .wakeUpTime(member.getWakeUpTime())
+            .build();
+        deletedMember.addDeletedMemberGoals(member.getMemberGoals());
+        return deletedMember;
+    }
+
+    private void addDeletedMemberGoals(List<MemberGoal> memberGoals) {
+        for (MemberGoal memberGoal : memberGoals) {
+            addDeletedMemberGoal(memberGoal);
+        }
+    }
+
+    private void addDeletedMemberGoal(MemberGoal memberGoal) {
+        DeletedMemberGoal deletedMemberGoal = DeletedMemberGoal.of(this, memberGoal);
+        this.deletedMemberGoals.add(deletedMemberGoal);
+    }
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/deleted/DeletedMemberGoal.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/deleted/DeletedMemberGoal.java
@@ -1,0 +1,47 @@
+package com.depromeet.domain.member.deleted;
+
+import com.depromeet.domain.BaseTimeEntity;
+import com.depromeet.domain.common.Category;
+import com.depromeet.domain.member.MemberGoal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class DeletedMemberGoal extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "deleted_member_id")
+    private DeletedMember deletedMember;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    private DeletedMemberGoal(DeletedMember deletedMember, Category category) {
+        this.deletedMember = deletedMember;
+        this.category = category;
+    }
+
+    public static DeletedMemberGoal of(DeletedMember deletedMember, MemberGoal memberGoal) {
+        return new DeletedMemberGoal(deletedMember, memberGoal.getCategory());
+    }
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/deleted/DeletedMemberGoalRepository.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/deleted/DeletedMemberGoalRepository.java
@@ -1,0 +1,10 @@
+package com.depromeet.domain.member.deleted;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 테스트용도의 Repository
+ */
+public interface DeletedMemberGoalRepository extends JpaRepository<DeletedMemberGoal, Long> {
+
+}

--- a/miracle-domain/src/main/java/com/depromeet/domain/member/deleted/DeletedMemberRepository.java
+++ b/miracle-domain/src/main/java/com/depromeet/domain/member/deleted/DeletedMemberRepository.java
@@ -1,0 +1,7 @@
+package com.depromeet.domain.member.deleted;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeletedMemberRepository extends JpaRepository<DeletedMember, Long> {
+
+}


### PR DESCRIPTION
## 회원 탈퇴 기능

회원 탈퇴시, Member 테이블에서 해당 정보가 삭제되고,
백업용도로 별도의 테이블(DeleteMember, DeleteMemberGoal)을 만들어서,
삭제된 Member 를 쌓도록 설계하였습니다~.

TODO// 나중에 특정 기간이 지나면 해당 테이블에서 완전히 삭제되도록 구현할 예정

이렇게 설계한 이유
1. 회원 탈퇴시, 특정 기간동안 백업이 필요했습니당.
2. Member 테이블에 isDeleted Flag 필드 주는 것보다 이런 방식이 좋다 판단하였슴당.